### PR TITLE
fix bug related to coordinates and dim swapping

### DIFF
--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -356,7 +356,8 @@ def test_swap_dims(all_mds_datadirs):
         assert 'i' not in xmitgcm.open_mdsdataset(dirname, **kwargs)
         ds = xmitgcm.open_mdsdataset(
                     dirname, geometry=expected['geometry'],
-                    iters=None, read_grid=True, swap_dims=True)
+                    iters=None, read_grid=True, swap_dims=True,
+                    grid_vars_to_coords=True)
 
         expected_dims = ['XC', 'XG', 'YC', 'YG', 'Z', 'Zl', 'Zp1', 'Zu']
 


### PR DESCRIPTION
I was getting errors when trying to swap dims due to the presence of coordinate variables. Solution is to be careful about the order of operations.

Should have been covered by the test suite but was not. Need to add more tests of that logic.