### PR TITLE
Added option for curvilinear grid, including rotation angles of grid

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -375,13 +375,13 @@ The physical dimensions of typical veriables are::
     >>> ('time', 'Zl', 'YC', 'XG')
 
 In order for physical dimensions to be assigned ``open_mdsdataset`` must be
-involved with ``read_grid=True`` (default). For a moree minimalistic approach,
+involved with ``read_grid=True`` (default). For a more minimalistic approach,
 one can use ``read_grid=False`` and assign logcial dimensions. Logical
 dimensions can also be chosen by explicitly setting ``swap_dims=False``, even
 with ``read_grid=False``.
 Physical dimension only work with ``geometry=='cartesian'`` or
-``geometry=='sphericalpolar'``. For ``geometry=='llc'``, it is not possible
-to replace the logical dimensions with physical dimensions, and setting
+``geometry=='sphericalpolar'``. For ``geometry=='llc'`` or ``geometry=='curvilinear'``,
+it is not possible to replace the logical dimensions with physical dimensions, and setting
 ``swap_dims=False`` will raise an error.
 
 Logical dimensions follow the naming conventions of the
@@ -448,8 +448,9 @@ Grid Geometries
 ---------------
 
 The grid geometry is not inferred; it must be specified via the ``geometry``
-keyword. xmitgcm currently supports three MITgcm grid geometries: ``cartesian``,
-``sphericalpolar``, and ``llc``.  The first two are straightforward. The ``llc``
+keyword. xmitgcm currently supports four MITgcm grid geometries: ``cartesian``,
+``sphericalpolar``, ``curvilinear``, and ``llc``.  The first two are straightforward.
+The ``curvilinear`` is used for curvilinear cartesian grids. The ``llc``
 ("lat-lon-cap") geometry is more complicated. This grid consists of four
 distinct faces of the same size plus a smaller north-polar cap. Each face has a
 distinct relatioship between its logical dimensions and its physical

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -103,7 +103,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
         if read_grid == False:
             swap_dims = False
         else:
-            swap_dims = False if geometry=='llc' else True
+            swap_dims = False if geometry in ('llc', 'curvilinear') else True
 
     # some checks for argument consistency
     if swap_dims and not read_grid:
@@ -223,7 +223,7 @@ def _swap_dimensions(ds, geometry, drop_old=True):
     # this fixes problems
     ds = ds.reset_coords()
 
-    if geometry.lower() == 'llc':
+    if geometry.lower() in ('llc', 'curvilinear'):
         raise ValueError("Can't swap dimensions if `geometry` is `llc`")
 
     # first squeeze all the coordinates

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -102,7 +102,19 @@ _experiments = {
                             'SIatmFW', 'oceQnet', 'oceFWflx', 'oceTAUX',
                             'oceTAUY', 'ADVxHEFF', 'ADVyHEFF', 'DFxEHEFF',
                             'DFyEHEFF', 'ADVxSNOW', 'ADVySNOW', 'DFxESNOW',
-                            'DFyESNOW', 'SIuice', 'SIvice'])}
+                            'DFyESNOW', 'SIuice', 'SIvice'])},
+    'curvilinear_leman': {'geometry': 'curvilinear',
+                          'delta_t': 20,
+                          'ref_date': "2013-11-12 12:00",
+                          'shape': (35, 64, 340),
+                          'test_iternum': 6,
+                          'dtype': np.dtype('f4'),
+                          'expected_values': {'XC': ((0,0), 501919.0)},
+                          'all_iters': [0, 3, 6],
+                          'expected_time':[
+                            (0, np.datetime64('2013-11-12T12:00:00.000000000')),
+                            (1, np.datetime64('2013-11-12T12:02:00.000000000'))],
+                          'prefixes': ['THETA']}
 }
 
 
@@ -423,7 +435,7 @@ def test_swap_dims(all_mds_datadirs):
     # make sure we never swap if not reading grid
     assert 'i' in xmitgcm.open_mdsdataset(dirname,
         iters=None, read_grid=False, geometry=expected['geometry'])
-    if expected['geometry'] == 'llc':
+    if expected['geometry'] in ('llc', 'curvilinear'):
         # make sure swapping is not the default
         assert 'i' in xmitgcm.open_mdsdataset(dirname, **kwargs)
         # and is impossible

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -109,7 +109,7 @@ _experiments = {
                           'shape': (35, 64, 340),
                           'test_iternum': 6,
                           'dtype': np.dtype('f4'),
-                          'expected_values': {'XC': ((0,0), 501919.0)},
+                          'expected_values': {'XC': ((0,0), 501919.21875)},
                           'all_iters': [0, 3, 6],
                           'expected_time':[
                             (0, np.datetime64('2013-11-12T12:00:00.000000000')),

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -75,6 +75,27 @@ horizontal_coordinates_spherical = OrderedDict(
                 units="degrees_north", coordinates="YG XG"))
 )
 
+horizontal_coordinates_curvcart = OrderedDict(
+    XC = dict(dims=["j", "i"], attrs=dict(
+                standard_name="plane_x_coordinate", long_name="x coordinate",
+                units="m", coordinate="YC XC")),
+    YC = dict(dims=["j", "i"], attrs=dict(
+                standard_name="plane_y_coordinate", long_name="y coordinate",
+                units="m", coordinate="YC XC")),
+    XG = dict(dims=["j_g", "i_g"], attrs=dict(
+                standard_name="plane_x_coordinate_at_f_location",
+                long_name="x coordinate", units="m", coordinate="YG XG")),
+    YG = dict(dims=["j_g", "i_g"], attrs=dict(
+                standard_name="plane_y_coordinate_at_f_location",
+                long_name="y coordinate", units="m", coordinates="YG XG")),
+    CS  = dict(dims=["j", "i"], attrs=dict(standard_name="Cos of grid orientation angle",
+               long_name="AngleCS", units=" ", coordinate="YC XC"),
+               filename='AngleCS'),
+    SN  = dict(dims=["j", "i"], attrs=dict(standard_name="Sin of grid orientation angle",
+               long_name="AngleSN", units=" ", coordinate="YC XC"),
+               filename='AngleSN')
+)
+
 horizontal_coordinates_cartesian = OrderedDict(
     XC = dict(dims=["j", "i"], attrs=dict(
                 standard_name="plane_x_coordinate", long_name="x coordinate",


### PR DESCRIPTION
I added an option to separately deal with Cartesian curvilinear grids. The only difference with standard Cartesian is that sine/cosine defining the grid rotation at each point are now being read.