### PR TITLE
Added fix_inconsistent_variables

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -153,7 +153,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
                     nx=nx, ny=ny, nz=nz)
                 datasets = [open_mdsdataset(
 
-                        data_dir, iters=iternum, read_grid=False, **kwargs)
+                        data_dir, iters=iternum, read_grid=True, **kwargs)
                     for iternum in iters]
                 # now add the grid
                 if read_grid:
@@ -408,18 +408,34 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         prefixes = []
         if read_grid:
             prefixes = prefixes + list(self._all_grid_variables.keys())
-
+            
         # add data files
         prefixes = (prefixes +
                     _get_all_matching_prefixes(
                                                data_dir,
                                                iternum,
                                                file_prefixes))
-
+    #In some older versions of mitgcm len(drC)=nr rather than nr+1
+    #Define a function to change it to the newer format if len(drC)=nr
+    #and apply it to the data before it is added to the xarray variable below
+    def fix_inconsistent_variables(data):
+        # check if the drC variable has the wrong length
+        if len(data)==self.nz:
+            # create a new array which will replace it
+            drc_data = np.zeros(self.nz + 1)
+            drc_data[:-1] = data
+            # fill in the missing value
+            drc_data[-1] = 0.5 * data[-1]
+            data = drc_data
+        return data
+    
         for p in prefixes:
             # use a generator to loop through the variables in each file
             for (vname, dims, data, attrs) in self.load_from_prefix(p, iternum):
                 # print(vname, dims, data.shape)
+                if vname == 'drC':
+                    data = fix_inconsistent_variables(data)
+
                 thisvar = xr.Variable(dims, data, attrs)
                 self._variables[vname] = thisvar
                 # print(type(data), type(thisvar._data), thisvar._in_memory)

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -179,7 +179,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
                           default_dtype=default_dtype,
                           nx=nx, ny=ny, nz=nz)
     ds = xr.Dataset.load_store(store)
-
+    
     if swap_dims:
         ds = _swap_dimensions(ds, geometry)
     if grid_vars_to_coords:
@@ -415,19 +415,20 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
                                                data_dir,
                                                iternum,
                                                file_prefixes))
-    #In some older versions of mitgcm len(drC)=nr rather than nr+1
-    #Define a function to change it to the newer format if len(drC)=nr
-    #and apply it to the data before it is added to the xarray variable below
-    def fix_inconsistent_variables(data):
-        # check if the drC variable has the wrong length
-        if len(data)==self.nz:
-            # create a new array which will replace it
-            drc_data = np.zeros(self.nz + 1)
-            drc_data[:-1] = data
-            # fill in the missing value
-            drc_data[-1] = 0.5 * data[-1]
-            data = drc_data
-        return data
+    
+        #In some older versions of mitgcm len(drC)=nr rather than nr+1
+        #Define a function to change it to the newer format if len(drC)=nr
+        #and apply it to the data before it is added to the xarray variable below
+        def fix_inconsistent_variables(data):
+            # check if the drC variable has the wrong length
+            if len(data)==self.nz:
+                # create a new array which will replace it
+                drc_data = np.zeros(self.nz + 1)
+                drc_data[:-1] = data
+                # fill in the missing value
+                drc_data[-1] = 0.5 * data[-1]
+                data = drc_data
+            return data
     
         for p in prefixes:
             # use a generator to loop through the variables in each file

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 import py
 import tempfile
 from glob import glob
+from shutil import copyfile
 
 import xmitgcm
 
@@ -620,3 +621,14 @@ def test_llc_dims(llc_mds_datadirs):
     assert ds.rA.dims == ('face', 'j', 'i')
     assert ds.U.dims == ('time', 'k', 'face', 'j', 'i_g')
     assert ds.V.dims == ('time', 'k', 'face', 'j_g', 'i')
+
+def test_drc_length(all_mds_datadirs):
+    """Test that open_mdsdataset is adding an extra level to drC if it has length nr"""
+    dirname, expected = all_mds_datadirs
+    #Only older versions of the gcm have len(drC) = nr, so force len(drC) = nr for the test
+    copyfile(os.path.join(dirname, 'DRF.data'), os.path.join(dirname, 'DRC.data'))
+    copyfile(os.path.join(dirname, 'DRF.meta'), os.path.join(dirname, 'DRC.meta'))
+    ds = xmitgcm.open_mdsdataset(
+                dirname, iters=None, read_grid=True,
+                geometry=expected['geometry'])
+    assert len(ds.drC)==(len(ds.drF)+1)


### PR DESCRIPTION
I added the function fix_inconsistent_variables to add the extra row onto drC.  This function is called after the data is read from the mds files but before the data is read into the xarray dataset.  Trying to change the drC array once it is in the xarray dataset causes problems, because xarray generates an error because the shape is different to what it expects.

I also changed read_grid=False to True on Line 165, as this seems to override the choice made when the user calls the function and so the grid wasn't being read.  I'm not sure what this should be in general.