### PR TITLE
Slight modifications to improve the use of the default_dtype parameter

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -295,7 +295,10 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         if endian not in ['>', '<', '=']:
             raise ValueError("Invalid byte order (endian=%s)" % endian)
         self.endian = endian
-        self.default_dtype = default_dtype
+        if default_dtype is not None:
+            self.default_dtype = np.dtype(default_dtype).newbyteorder(endian)
+        else:
+            self.default_dtype = default_dtype
 
         # storage dicts for variables and attributes
         self._variables = xr.core.pycompat.OrderedDict()

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -447,6 +447,12 @@ def test_open_dataset_no_meta(all_mds_datadirs):
         assert ds['Eta'].dims == dims_2d
         assert ds['Eta'].values.ndim == len(dims_2d)
 
+        with pytest.raises(IOError, message="Expecting IOError when default_dtype "
+                                            "is not precised (i.e., None)"):
+            xmitgcm.open_mdsdataset(dirname, prefix=['T', 'Eta'], iters=it,
+                                    geometry=expected['geometry'],
+                                    read_grid=False)
+
     # now get rid of the variables used to infer dimensions
     with hide_file(dirname, 'XC.meta', 'RC.meta'):
         with pytest.raises(IOError):

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -87,11 +87,14 @@ def read_mds(fname, iternum=None, use_mmap=True, force_dict=True, endian='>',
     try:
         nrecs, shape, name, dtype, fldlist = get_useful_info_from_meta_file(metafile)
         dtype = dtype.newbyteorder(endian)
-    except IOError as e:
+    except IOError:
         # we can recover from not having a .meta file if dtype and shape have
         # been specified already
-        if (shape is None) or (dtype is None):
-            raise e
+        if shape is None:
+            raise IOError("Cannot find the shape associated to %s in the metadata." %fname)
+        elif dtype is None:
+            raise IOError("Cannot find the dtype associated to %s in the metadata, "
+                          "please specify the default dtype to avoid this error." %fname)
         else:
             nrecs = 1
             shape = list(shape)


### PR DESCRIPTION
* Check the default_dtype to add if necessary the default endian

* Modify the IOError when the metadata is absent and the default_dtype is needed

* Add a test to check if an IOError is correctly raised when there is no metadata and default_dtype is None