### PR TITLE
Tests for ref_date issue

### DIFF
--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -749,78 +749,44 @@ def test_drc_length(all_mds_datadirs):
 # Series of tests which try to open a dataset with different combinations of
 # of options, to identify if ref_date can trigger an error
 #
-def test_print_with_ref_date_without_grid(mds_datadirs_with_refdate):
+@pytest.mark.parametrize("method", [True, False])
+def test_print_with_ref_date_grid(mds_datadirs_with_refdate, method):
     """With ref_date, without grid."""
     dirname, expected = mds_datadirs_with_refdate
 
     ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
-                                 ref_date=expected['ref_date'], read_grid=False,
+                                 ref_date=expected['ref_date'], read_grid=method,
                                  delta_t=expected['delta_t'],
                                  geometry=expected['geometry'])
     print(ds)
 
-def test_print_with_ref_date_with_grid(mds_datadirs_with_refdate):
+@pytest.mark.parametrize("method", [True, False])
+def test_print_with_ref_date_swap(mds_datadirs_with_refdate, method):
     """With ref_date, without grid."""
     dirname, expected = mds_datadirs_with_refdate
 
     ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
                                  ref_date=expected['ref_date'], read_grid=True,
-                                 delta_t=expected['delta_t'],
+                                 delta_t=expected['delta_t'], swap_dims=method,
                                  geometry=expected['geometry'])
     print(ds)
 
-def test_print_with_ref_date_with_swap(mds_datadirs_with_refdate):
+@pytest.mark.parametrize("method", [True, False])
+def test_open_with_ref_date_grid(mds_datadirs_with_refdate, method):
     """With ref_date, without grid."""
     dirname, expected = mds_datadirs_with_refdate
 
     ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
-                                 ref_date=expected['ref_date'], read_grid=True,
-                                 delta_t=expected['delta_t'], swap_dims=True,
-                                 geometry=expected['geometry'])
-    print(ds)
-
-def test_print_with_ref_date_without_swap(mds_datadirs_with_refdate):
-    """With ref_date, without grid."""
-    dirname, expected = mds_datadirs_with_refdate
-
-    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
-                                 ref_date=expected['ref_date'], read_grid=True,
-                                 delta_t=expected['delta_t'], swap_dims=False,
-                                 geometry=expected['geometry'])
-    print(ds)
-
-def test_open_with_ref_date_without_grid(mds_datadirs_with_refdate):
-    """With ref_date, without grid."""
-    dirname, expected = mds_datadirs_with_refdate
-
-    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
-                                 ref_date=expected['ref_date'], read_grid=False,
+                                 ref_date=expected['ref_date'], read_grid=method,
                                  delta_t=expected['delta_t'],
                                  geometry=expected['geometry'])
 
-def test_open_with_ref_date_with_grid(mds_datadirs_with_refdate):
+@pytest.mark.parametrize("method", [True, False])
+def test_open_with_ref_date_swap(mds_datadirs_with_refdate, method):
     """With ref_date, without grid."""
     dirname, expected = mds_datadirs_with_refdate
 
     ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
                                  ref_date=expected['ref_date'], read_grid=True,
-                                 delta_t=expected['delta_t'],
-                                 geometry=expected['geometry'])
-
-def test_open_with_ref_date_with_swap(mds_datadirs_with_refdate):
-    """With ref_date, without grid."""
-    dirname, expected = mds_datadirs_with_refdate
-
-    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
-                                 ref_date=expected['ref_date'], read_grid=True,
-                                 delta_t=expected['delta_t'], swap_dims=True,
-                                 geometry=expected['geometry'])
-
-def test_open_with_ref_date_without_swap(mds_datadirs_with_refdate):
-    """With ref_date, without grid."""
-    dirname, expected = mds_datadirs_with_refdate
-
-    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
-                                 ref_date=expected['ref_date'], read_grid=True,
-                                 delta_t=expected['delta_t'], swap_dims=False,
+                                 delta_t=expected['delta_t'], swap_dims=method,
                                  geometry=expected['geometry'])

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -750,7 +750,7 @@ def test_drc_length(all_mds_datadirs):
 # of options, to identify if ref_date can trigger an error
 #
 @pytest.mark.parametrize("method", [True, False])
-def test_print_with_ref_date_grid(mds_datadirs_with_refdate, method):
+def test_tload_with_ref_date_grid(mds_datadirs_with_refdate, method):
     """With ref_date, without grid."""
     dirname, expected = mds_datadirs_with_refdate
 
@@ -758,10 +758,10 @@ def test_print_with_ref_date_grid(mds_datadirs_with_refdate, method):
                                  ref_date=expected['ref_date'], read_grid=method,
                                  delta_t=expected['delta_t'],
                                  geometry=expected['geometry'])
-    print(ds)
+    ds.time.load()
 
 @pytest.mark.parametrize("method", [True, False])
-def test_print_with_ref_date_swap(mds_datadirs_with_refdate, method):
+def test_tload_with_ref_date_swap(mds_datadirs_with_refdate, method):
     """With ref_date, without grid."""
     dirname, expected = mds_datadirs_with_refdate
 
@@ -769,7 +769,7 @@ def test_print_with_ref_date_swap(mds_datadirs_with_refdate, method):
                                  ref_date=expected['ref_date'], read_grid=True,
                                  delta_t=expected['delta_t'], swap_dims=method,
                                  geometry=expected['geometry'])
-    print(ds)
+    ds.time.load()
 
 @pytest.mark.parametrize("method", [True, False])
 def test_open_with_ref_date_grid(mds_datadirs_with_refdate, method):

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -343,6 +343,7 @@ def test_read_raw_data_llc(llc_mds_datadirs, method, memmap):
     assert data.shape == shape_2d
     assert data.compute().shape == shape_2d
 
+
 #########################################################
 ### Below are all tests that actually create datasets ###
 #########################################################
@@ -742,3 +743,84 @@ def test_drc_length(all_mds_datadirs):
                 dirname, iters=None, read_grid=True,
                 geometry=expected['geometry'])
     assert len(ds.drC)==(len(ds.drF)+1)
+
+
+#
+# Series of tests which try to open a dataset with different combinations of
+# of options, to identify if ref_date can trigger an error
+#
+def test_print_with_ref_date_without_grid(mds_datadirs_with_refdate):
+    """With ref_date, without grid."""
+    dirname, expected = mds_datadirs_with_refdate
+
+    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
+                                 ref_date=expected['ref_date'], read_grid=False,
+                                 delta_t=expected['delta_t'],
+                                 geometry=expected['geometry'])
+    print(ds)
+
+def test_print_with_ref_date_with_grid(mds_datadirs_with_refdate):
+    """With ref_date, without grid."""
+    dirname, expected = mds_datadirs_with_refdate
+
+    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
+                                 ref_date=expected['ref_date'], read_grid=True,
+                                 delta_t=expected['delta_t'],
+                                 geometry=expected['geometry'])
+    print(ds)
+
+def test_print_with_ref_date_with_swap(mds_datadirs_with_refdate):
+    """With ref_date, without grid."""
+    dirname, expected = mds_datadirs_with_refdate
+
+    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
+                                 ref_date=expected['ref_date'], read_grid=True,
+                                 delta_t=expected['delta_t'], swap_dims=True,
+                                 geometry=expected['geometry'])
+    print(ds)
+
+def test_print_with_ref_date_without_swap(mds_datadirs_with_refdate):
+    """With ref_date, without grid."""
+    dirname, expected = mds_datadirs_with_refdate
+
+    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
+                                 ref_date=expected['ref_date'], read_grid=True,
+                                 delta_t=expected['delta_t'], swap_dims=False,
+                                 geometry=expected['geometry'])
+    print(ds)
+
+def test_open_with_ref_date_without_grid(mds_datadirs_with_refdate):
+    """With ref_date, without grid."""
+    dirname, expected = mds_datadirs_with_refdate
+
+    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
+                                 ref_date=expected['ref_date'], read_grid=False,
+                                 delta_t=expected['delta_t'],
+                                 geometry=expected['geometry'])
+
+def test_open_with_ref_date_with_grid(mds_datadirs_with_refdate):
+    """With ref_date, without grid."""
+    dirname, expected = mds_datadirs_with_refdate
+
+    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
+                                 ref_date=expected['ref_date'], read_grid=True,
+                                 delta_t=expected['delta_t'],
+                                 geometry=expected['geometry'])
+
+def test_open_with_ref_date_with_swap(mds_datadirs_with_refdate):
+    """With ref_date, without grid."""
+    dirname, expected = mds_datadirs_with_refdate
+
+    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
+                                 ref_date=expected['ref_date'], read_grid=True,
+                                 delta_t=expected['delta_t'], swap_dims=True,
+                                 geometry=expected['geometry'])
+
+def test_open_with_ref_date_without_swap(mds_datadirs_with_refdate):
+    """With ref_date, without grid."""
+    dirname, expected = mds_datadirs_with_refdate
+
+    ds = xmitgcm.open_mdsdataset(dirname, iters='all', prefix=['S'],
+                                 ref_date=expected['ref_date'], read_grid=True,
+                                 delta_t=expected['delta_t'], swap_dims=False,
+                                 geometry=expected['geometry'])


### PR DESCRIPTION
8 tests which either open or open+print a dataset in 4 different ways, always using `ref_date`, plus `read_grid=True/False` and `read_grid=True, swap_dims=True/False`