### PR TITLE
Cast `prefix` to list if it isn't already one

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -119,6 +119,12 @@ def open_mdsdataset(data_dir, grid_dir=None,
     if swap_dims and not read_grid:
         raise ValueError("If swap_dims==True, read_grid must be True.")
 
+    # if prefix is passed as a string, force it to be a list
+    if type(prefix) is str:
+        prefix = [prefix]
+    else:
+        pass
+
     # We either have a single iter, in which case we create a fresh store,
     # or a list of iters, in which case we combine.
     if iters == 'all':

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -120,7 +120,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
         raise ValueError("If swap_dims==True, read_grid must be True.")
 
     # if prefix is passed as a string, force it to be a list
-    if type(prefix) is str:
+    if type(prefix) is str or unicode:
         prefix = [prefix]
     else:
         pass


### PR DESCRIPTION
As described in #78, it's possible to get an obtuse error message when attempting to load in multiple timestamps with a single `prefix`.

This PR introduces a fix that checks whether `prefix` is a string, and if it is, casts it to a list. If anything other than a string is passed this PR changes nothing.

This closes #78 for me, but, there's more to it than I first thought.

I tried to make some tests fail by loading in multiple iterations with a single prefix, but unexpectedly they passed. It seems that this error only appears when loading in files produced by `pkg/diagnostics` - at least, that's what I've found after trying various combinations with the model output I had to hand. As far as I can tell the test suite doesn't come with multiple timestamps of files from `pkg/diagnostics`, so there's currently no way to make it replicate this error.

I'll leave it up to you whether you want to enhance the test suite or not, but I'm curious about why this works when the output isn't from `pkg/diagnostics`.