### PR TITLE
extend capabilities of read_raw_data

### DIFF
--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -198,27 +198,26 @@ def test_parse_meta(tmpdir):
     for k, v in expected.items():
         assert result[k] == v
 
-
-def test_read_raw_data(tmpdir):
+@pytest.mark.parametrize("dtype", [np.dtype('f8'), np.dtype('f4'), np.dtype('i4')])
+def test_read_raw_data(tmpdir,dtype):
     """Check our utility for reading raw data."""
 
     from xmitgcm.utils import read_raw_data
     shape = (2, 4)
-    for dtype in [np.dtype('f8'), np.dtype('f4'), np.dtype('i4')]:
-        # create some test data
-        testdata = np.zeros(shape, dtype)
-        # write to a file
-        datafile = tmpdir.join("tmp.data")
-        datafile.write_binary(testdata.tobytes())
-        fname = str(datafile)
-        # now test the function
-        data = read_raw_data(fname, dtype, shape)
-        np.testing.assert_allclose(data, testdata)
-        # interestingly, memmaps are also ndarrays, but not vice versa
-        assert isinstance(data, np.ndarray) and not isinstance(data, np.memmap)
-        # check memmap
-        mdata = read_raw_data(fname, dtype, shape, use_mmap=True)
-        assert isinstance(mdata, np.memmap)
+    # create some test data
+    testdata = np.zeros(shape, dtype)
+    # write to a file
+    datafile = tmpdir.join("tmp.data")
+    datafile.write_binary(testdata.tobytes())
+    fname = str(datafile)
+    # now test the function
+    data = read_raw_data(fname, dtype, shape)
+    np.testing.assert_allclose(data, testdata)
+    # interestingly, memmaps are also ndarrays, but not vice versa
+    assert isinstance(data, np.ndarray) and not isinstance(data, np.memmap)
+    # check memmap
+    mdata = read_raw_data(fname, dtype, shape, use_mmap=True)
+    assert isinstance(mdata, np.memmap)
 
     # make sure errors are correct
     wrongshape = (2, 5)
@@ -228,29 +227,28 @@ def test_read_raw_data(tmpdir):
     # test optional functionalities
     shape = (5, 15, 10)
     shape_subset = (15, 10)
-    for dtype in [np.dtype('f8'), np.dtype('f4'), np.dtype('i4')]:
-        testdata = np.zeros(shape, dtype)
-        # create some test data
-        x = np.arange(shape[0], dtype=dtype)
-        for k in np.arange(shape[0]):
-            testdata[k, :, :] = x[k]
-        # write to a file
-        datafile = tmpdir.join("tmp.data")
-        datafile.write_binary(testdata.tobytes())
-        fname = str(datafile)
-        # now test the function
-        for k in np.arange(shape[0]):
-            offset = (k * shape[1] * shape[2] * dtype.itemsize)
-            data = read_raw_data(fname, dtype, shape_subset,
-                                 offset=offset, partial_read=True)
-            np.testing.assert_allclose(data, testdata[k, :, :])
-            assert isinstance(data, np.ndarray) and not isinstance(
-                data, np.memmap)
-            # check memmap
-            mdata = read_raw_data(fname, dtype, shape_subset,
-                                  offset=offset, partial_read=True,
-                                  use_mmap=True)
-            assert isinstance(mdata, np.memmap)
+    testdata = np.zeros(shape, dtype)
+    # create some test data
+    x = np.arange(shape[0], dtype=dtype)
+    for k in np.arange(shape[0]):
+        testdata[k, :, :] = x[k]
+    # write to a file
+    datafile = tmpdir.join("tmp.data")
+    datafile.write_binary(testdata.tobytes())
+    fname = str(datafile)
+    # now test the function
+    for k in np.arange(shape[0]):
+        offset = (k * shape[1] * shape[2] * dtype.itemsize)
+        data = read_raw_data(fname, dtype, shape_subset,
+                             offset=offset, partial_read=True)
+        np.testing.assert_allclose(data, testdata[k, :, :])
+        assert isinstance(data, np.ndarray) and not isinstance(
+            data, np.memmap)
+        # check memmap
+        mdata = read_raw_data(fname, dtype, shape_subset,
+                              offset=offset, partial_read=True,
+                              use_mmap=True)
+        assert isinstance(mdata, np.memmap)
 
         # test it breaks when it should
         with pytest.raises(IOError):
@@ -273,8 +271,6 @@ def test_read_raw_data(tmpdir):
                 use_mmap=True)
 
 # a meta test
-
-
 def test_file_hiding(all_mds_datadirs):
     dirname, _ = all_mds_datadirs
     basenames = ['XC.data', 'XC.meta']

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -255,17 +255,21 @@ def test_read_raw_data(tmpdir,dtype):
             # read with wrong shape
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=0, partial_read=False)
+        with pytest.raises(IOError):
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=0, partial_read=False, use_mmap=True)
         with pytest.raises(ValueError):
             # use offset when trying to read global file
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=4, partial_read=False)
+        with pytest.raises(ValueError):
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=4, partial_read=False, use_mmap=True)
             # offset is too big
+        with pytest.raises(ValueError):
             _ = read_raw_data(fname, dtype, shape, offset=(
                 shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
+        with pytest.raises(ValueError):
             _ = read_raw_data(fname, dtype, shape, offset=(
                 shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,
                 use_mmap=True)

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -267,7 +267,8 @@ def test_read_raw_data(tmpdir):
             _ = read_raw_data(fname, dtype, shape, offset=(
                 shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
             _ = read_raw_data(fname, dtype, shape, offset=(
-                shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,use_mmap=True)
+                shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,
+                use_mmap=True)
 
 # a meta test
 

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -226,14 +226,14 @@ def test_read_raw_data(tmpdir):
         _ = read_raw_data(fname, dtype, wrongshape)
 
     # test optional functionalities
-    shape = (5,15,10)
+    shape = (5, 15, 10)
     shape_subset = (15, 10)
     for dtype in [np.dtype('f8'), np.dtype('f4'), np.dtype('i4')]:
         testdata = np.zeros(shape, dtype)
         # create some test data
-        x = np.arange(shape[0],dtype=dtype)
+        x = np.arange(shape[0], dtype=dtype)
         for k in np.arange(shape[0]):
-            testdata[k,:,:] = x[k]
+            testdata[k, :, :] = x[k]
         # write to a file
         datafile = tmpdir.join("tmp.data")
         datafile.write_binary(testdata.tobytes())
@@ -241,20 +241,26 @@ def test_read_raw_data(tmpdir):
         # now test the function
         for k in np.arange(shape[0]):
             offset = (k * shape[1] * shape[2] * dtype.itemsize)
-            data = read_raw_data(fname, dtype, shape_subset,offset=offset,partial_read=True)
-            np.testing.assert_allclose(data, testdata[k,:,:])
+            data = read_raw_data(fname, dtype, shape_subset,
+                                 offset=offset, partial_read=True)
+            np.testing.assert_allclose(data, testdata[k, :, :])
 
         # test it breaks when it should
         with pytest.raises(IOError):
             # read with wrong shape
-            _ = read_raw_data(fname, dtype, shape_subset,offset=0,partial_read=False)
+            _ = read_raw_data(fname, dtype, shape_subset,
+                              offset=0, partial_read=False)
         with pytest.raises(ValueError):
             # use offset when trying to read global file
-            _ = read_raw_data(fname, dtype, shape_subset,offset=4,partial_read=False)
+            _ = read_raw_data(fname, dtype, shape_subset,
+                              offset=4, partial_read=False)
             # offset is too big
-            _ = read_raw_data(fname, dtype, shape,offset=(shape[0]*shape[1]*shape[2]*dtype.itemsize),partial_read=True)
+            _ = read_raw_data(fname, dtype, shape, offset=(
+                shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
 
 # a meta test
+
+
 def test_file_hiding(all_mds_datadirs):
     dirname, _ = all_mds_datadirs
     basenames = ['XC.data', 'XC.meta']

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -264,11 +264,12 @@ def test_read_raw_data(tmpdir,dtype):
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=4, partial_read=False, use_mmap=True)
             # offset is too big
-            _ = read_raw_data(fname, dtype, shape, offset=(
-                shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
-            _ = read_raw_data(fname, dtype, shape, offset=(
-                shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,
-                use_mmap=True)
+           for k in np.arange(50):
+                _ = read_raw_data(fname, dtype, shape, offset=(
+                    shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
+                _ = read_raw_data(fname, dtype, shape, offset=(
+                    shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,
+                    use_mmap=True)
 
 # a meta test
 def test_file_hiding(all_mds_datadirs):

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -244,19 +244,30 @@ def test_read_raw_data(tmpdir):
             data = read_raw_data(fname, dtype, shape_subset,
                                  offset=offset, partial_read=True)
             np.testing.assert_allclose(data, testdata[k, :, :])
+            assert isinstance(data, np.ndarray) and not isinstance(data, np.memmap)
+            # check memmap
+            mdata = read_raw_data(fname, dtype, shape_subset,
+                                  offset=offset, partial_read=True,use_mmap=True)
+            assert isinstance(mdata, np.memmap)
 
         # test it breaks when it should
         with pytest.raises(IOError):
             # read with wrong shape
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=0, partial_read=False)
+            _ = read_raw_data(fname, dtype, shape_subset,
+                              offset=0, partial_read=False,use_mmap=True)
         with pytest.raises(ValueError):
             # use offset when trying to read global file
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=4, partial_read=False)
+            _ = read_raw_data(fname, dtype, shape_subset,
+                              offset=4, partial_read=False,use_mmap=True)
             # offset is too big
             _ = read_raw_data(fname, dtype, shape, offset=(
                 shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
+            _ = read_raw_data(fname, dtype, shape, offset=(
+                shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,use_mmap=True)
 
 # a meta test
 

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -225,6 +225,34 @@ def test_read_raw_data(tmpdir):
     with pytest.raises(IOError):
         _ = read_raw_data(fname, dtype, wrongshape)
 
+    # test optional functionalities
+    shape = (5,15,10)
+    shape_subset = (15, 10)
+    for dtype in [np.dtype('f8'), np.dtype('f4'), np.dtype('i4')]:
+        testdata = np.zeros(shape, dtype)
+        # create some test data
+        x = np.arange(shape[0],dtype=dtype)
+        for k in np.arange(shape[0]):
+            testdata[k,:,:] = x[k]
+        # write to a file
+        datafile = tmpdir.join("tmp.data")
+        datafile.write_binary(testdata.tobytes())
+        fname = str(datafile)
+        # now test the function
+        for k in np.arange(shape[0]):
+            offset = (k * shape[1] * shape[2] * dtype.itemsize)
+            data = read_raw_data(fname, dtype, shape_subset,offset=offset,partial_read=True)
+            np.testing.assert_allclose(data, testdata[k,:,:])
+
+        # test it breaks when it should
+        with pytest.raises(IOError):
+            # read with wrong shape
+            _ = read_raw_data(fname, dtype, shape_subset,offset=0,partial_read=False)
+        with pytest.raises(ValueError):
+            # use offset when trying to read global file
+            _ = read_raw_data(fname, dtype, shape_subset,offset=4,partial_read=False)
+            # offset is too big
+            _ = read_raw_data(fname, dtype, shape,offset=(shape[0]*shape[1]*shape[2]*dtype.itemsize),partial_read=True)
 
 # a meta test
 def test_file_hiding(all_mds_datadirs):

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -248,7 +248,8 @@ def test_read_raw_data(tmpdir):
                 data, np.memmap)
             # check memmap
             mdata = read_raw_data(fname, dtype, shape_subset,
-                                  offset=offset, partial_read=True, use_mmap=True)
+                                  offset=offset, partial_read=True,
+                                  use_mmap=True)
             assert isinstance(mdata, np.memmap)
 
         # test it breaks when it should

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -264,7 +264,7 @@ def test_read_raw_data(tmpdir,dtype):
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=4, partial_read=False, use_mmap=True)
             # offset is too big
-           for k in np.arange(50):
+            for k in np.arange(50):
                 _ = read_raw_data(fname, dtype, shape, offset=(
                     shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
                 _ = read_raw_data(fname, dtype, shape, offset=(

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -264,12 +264,11 @@ def test_read_raw_data(tmpdir,dtype):
             _ = read_raw_data(fname, dtype, shape_subset,
                               offset=4, partial_read=False, use_mmap=True)
             # offset is too big
-            for k in np.arange(50):
-                _ = read_raw_data(fname, dtype, shape, offset=(
-                    shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
-                _ = read_raw_data(fname, dtype, shape, offset=(
-                    shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,
-                    use_mmap=True)
+            _ = read_raw_data(fname, dtype, shape, offset=(
+                shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True)
+            _ = read_raw_data(fname, dtype, shape, offset=(
+                shape[0]*shape[1]*shape[2]*dtype.itemsize), partial_read=True,
+                use_mmap=True)
 
 # a meta test
 def test_file_hiding(all_mds_datadirs):

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -240,7 +240,13 @@ def read_raw_data(datafile, dtype, shape, use_mmap=False, offset=0,
                            actual_number_of_bytes))
     else:
         pass
-    assert(offset < actual_number_of_bytes), 'offset greater than filesize'
+
+    if offset < actual_number_of_bytes:
+        pass
+    else:
+        raise ValueError('bytes offset %g is greater than file size %g' %
+                         (offset, actual_number_of_bytes))
+
     with open(datafile, 'rb') as f:
         if use_mmap:
             data = np.memmap(f, dtype=dtype, mode='r', offset=offset,

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -240,11 +240,9 @@ def read_raw_data(datafile, dtype, shape, use_mmap=False, offset=0,
                            actual_number_of_bytes))
     else:
         pass
-
     if offset >= actual_number_of_bytes:
         raise ValueError('bytes offset %g is greater than file size %g' %
                          (offset, actual_number_of_bytes))
-
     with open(datafile, 'rb') as f:
         if use_mmap:
             data = np.memmap(f, dtype=dtype, mode='r', offset=offset,

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -240,9 +240,7 @@ def read_raw_data(datafile, dtype, shape, use_mmap=False, offset=0,
                            actual_number_of_bytes))
     else:
         pass
-    if offset >= actual_number_of_bytes:
-        raise ValueError('bytes offset %g is greater than file size %g' %
-                         (offset, actual_number_of_bytes))
+    assert(offset < actual_number_of_bytes), 'offset greater than filesize'
     with open(datafile, 'rb') as f:
         if use_mmap:
             data = np.memmap(f, dtype=dtype, mode='r', offset=offset,

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -231,7 +231,7 @@ def read_raw_data(datafile, dtype, shape, use_mmap=False, offset=0,
         if offset != 0:
             raise ValueError(
                 'When partial_read==False, offset will not be read')
-        # second check to be sure there is the right number of bytes in the file
+        # second check to be sure there is the right number of bytes in file
         if expected_number_of_bytes != actual_number_of_bytes:
             raise IOError('File `%s` does not have the correct size '
                           '(expected %g, found %g)' %

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -229,7 +229,8 @@ def read_raw_data(datafile, dtype, shape, use_mmap=False, offset=0,
     if not partial_read:
         # first check that partial_read and offset are used together
         if offset != 0:
-            raise ValueError('When partial_read==False, offset will not be read')
+            raise ValueError(
+                'When partial_read==False, offset will not be read')
         # second check to be sure there is the right number of bytes in the file
         if expected_number_of_bytes != actual_number_of_bytes:
             raise IOError('File `%s` does not have the correct size '


### PR DESCRIPTION
* possibility to read part of the file, with offset and partial_read
* choice of row/column major order

This will allow the refactor of read_mds by putting the np.fromfile and np.memmap
calls into one generic function