### PR TITLE
refactoring mds_store to include the option to pass extra metadata

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -505,18 +505,19 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         # add data files
         prefixes = (prefixes +
                     _get_all_matching_prefixes(
-                                               data_dir,
-                                               iternum,
-                                               file_prefixes))
+                        data_dir,
+                        iternum,
+                        file_prefixes))
 
         for p in prefixes:
             # use a generator to loop through the variables in each file
             for (vname, dims, data, attrs) in \
-                self.load_from_prefix(p, iternum, extra_metadata):
+                    self.load_from_prefix(p, iternum, extra_metadata):
                 # print(vname, dims, data.shape)
-                #Sizes of grid variables can vary between mitgcm versions. Check for
-                #such inconsistency and correct if so
-                (vname, dims, data, attrs) = self.fix_inconsistent_variables(vname, dims, data, attrs)
+                # Sizes of grid variables can vary between mitgcm versions. Check for
+                # such inconsistency and correct if so
+                (vname, dims, data, attrs) = self.fix_inconsistent_variables(
+                    vname, dims, data, attrs)
 
                 thisvar = xr.Variable(dims, data, attrs)
                 self._variables[vname] = thisvar

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -651,7 +651,6 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
                 data = np.atleast_1d(np.asarray(data).squeeze())
 
             if self.llc:
-                print(dims, data)
                 dims, data = _reshape_for_llc(dims, data)
 
             # need to add an extra dimension at the beginning if we have a time

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -24,7 +24,8 @@ from .variables import dimensions, \
 # would it be better to import mitgcm_variables and then automate the search
 # for variable dictionaries
 
-from .utils import parse_meta_file, read_mds, parse_available_diagnostics
+from .utils import parse_meta_file, read_mds, parse_available_diagnostics,\
+                   get_extra_metadata
 
 # Python2/3 compatibility
 if (sys.version_info > (3, 0)):
@@ -45,7 +46,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
                     endian=">", chunks=None,
                     ignore_unknown_vars=False, default_dtype=None,
                     nx=None, ny=None, nz=None,
-                    llc_method="smallchunks"):
+                    llc_method="smallchunks", extra_metadata=None):
     """Open MITgcm-style mds (.data / .meta) file output as xarray datset.
 
     Parameters
@@ -99,6 +100,22 @@ def open_mdsdataset(data_dir, grid_dir=None,
         ``dask.array.concatenate``. The different methods will have different
         memory and i/o performance depending on the details of the system
         configuration.
+    extra_metadata : dict, optional
+        Allow to pass information on llc type grid (global or regional).
+        The additional metadata is typically such as :
+
+        aste = {'has_faces': True, 'ny': 1350, 'nx': 270,
+                'ny_facets': [450,0,270,180,450],
+                'pad_before_y': [90,0,0,0,0],
+                'pad_after_y': [0,0,0,90,90],
+                'face_facets': [0, 0, 2, 3, 4, 4],
+                'facet_orders' : ['C', 'C', 'C', 'F', 'F'],
+                'face_offsets' : [0, 1, 0, 0, 0, 1],
+                'transpose_face' : [False, False, False,
+                                    True, True, True]}
+
+        For global llc grids, no extra metadata is required and code
+        will set up to global llc default configuration.
 
     Returns
     -------
@@ -175,7 +192,8 @@ def open_mdsdataset(data_dir, grid_dir=None,
                     endian=endian, chunks=chunks,
                     ignore_unknown_vars=ignore_unknown_vars,
                     default_dtype=default_dtype,
-                    nx=nx, ny=ny, nz=nz, llc_method=llc_method)
+                    nx=nx, ny=ny, nz=nz, llc_method=llc_method,
+                    extra_metadata=extra_metadata)
                 datasets = [open_mdsdataset(
                         data_dir, iters=iternum, read_grid=False, **kwargs)
                     for iternum in iters]
@@ -201,7 +219,8 @@ def open_mdsdataset(data_dir, grid_dir=None,
                           geometry, endian,
                           ignore_unknown_vars=ignore_unknown_vars,
                           default_dtype=default_dtype,
-                          nx=nx, ny=ny, nz=nz, llc_method=llc_method)
+                          nx=nx, ny=ny, nz=nz, llc_method=llc_method,
+                          extra_metadata=extra_metadata)
     ds = xr.Dataset.load_store(store)
 
     if swap_dims:
@@ -296,7 +315,8 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
                  geometry='sphericalpolar',
                  endian='>', ignore_unknown_vars=False,
                  default_dtype=np.dtype('f4'),
-                 nx=None, ny=None, nz=None, llc_method="smallchunks"):
+                 nx=None, ny=None, nz=None, llc_method="smallchunks",
+                 extra_metadata=None):
         """
         This is not a user-facing class. See open_mdsdataset for argument
         documentation. The only ones which are distinct are.
@@ -345,9 +365,27 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         else:
             self.nz = nz
 
+        self.extra_metadata = extra_metadata if extra_metadata is not None \
+            else None
+
+        # put in local variable to make it more readable
+        if extra_metadata is not None and 'has_faces' in extra_metadata:
+            has_faces = extra_metadata['has_faces']
+        else:
+            has_faces = False
+
+        # --------------- LEGACY ----------------------
+        if self.llc:
+            has_faces = True
+            if extra_metadata is None or 'ny_facets' not in extra_metadata:
+                # default to llc90, we only need number of facets
+                # and we cannot know nx at this point
+                llc = get_extra_metadata(domain='llc', nx=90)
+                self.extra_metadata = llc
+        # --------------- /LEGACY ----------------------
 
         # we don't need to know ny if using llc
-        if self.llc and (nx is not None):
+        if has_faces and (nx is not None):
             ny = nx
 
         # Now we need to figure out the horizontal dimensions nx, ny
@@ -356,15 +394,24 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
             # we have been passed enough information to determine the
             # dimensions without reading any files
             self.ny, self.nx = ny, nx
-            self.nface = LLC_NUM_FACES if self.llc else None
+            self.nface = len(self.extra_metadata['face_facets']) if has_faces \
+                else None
         else:
             # have to peek at the grid file metadata
             self.nface, self.ny, self.nx = (
                 _guess_model_horiz_dims(self.grid_dir, self.llc))
 
+        # --------------- LEGACY ----------------------
+        if self.llc:
+            if extra_metadata is None or 'ny_facets' not in extra_metadata:
+                # default to llc
+                llc = get_extra_metadata(domain='llc', nx=self.nx)
+                self.extra_metadata = llc
+        # --------------- /LEGACY ----------------------
+
         self.layers = _guess_layers(data_dir)
 
-        if self.llc:
+        if has_faces:
             nyraw = self.nx*self.nface
         else:
             nyraw = self.ny
@@ -405,7 +452,7 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         # possibly add the llc dimension
         # seems sloppy to hard code this here
         # TODO: move this metadata to variables.py
-        if self.llc:
+        if has_faces:
             self._dimensions.append(LLC_FACE_DIMNAME)
             data = np.arange(self.nface)
             attrs = {'standard_name': 'face_index'}
@@ -528,7 +575,8 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         basename = os.path.join(ddir, fname_base)
         try:
             vardata = read_mds(basename, iternum, endian=self.endian,
-                               llc=self.llc, llc_method=self.llc_method)
+                               llc=self.llc, llc_method=self.llc_method,
+                               extra_metadata=self.extra_metadata)
         except IOError as ioe:
             # that might have failed because there was no meta file present
             # we can try to get around this by specifying the shape and dtype
@@ -536,18 +584,19 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
                 ndims = len(self._all_data_variables[prefix]['dims'])
             except KeyError:
                 ndims = 3
-            if ndims==3 and self.nz > 1:
+            if ndims == 3 and self.nz > 1:
                 data_shape = self.default_shape_3D
-            elif ndims==2 or self.nz == 1:
+            elif ndims == 2 or self.nz == 1:
                 data_shape = self.default_shape_2D
             else:
                 raise ValueError("Can't determine shape "
-                                 "of variable %s" %  prefix)
+                                 "of variable %s" % prefix)
 
             vardata = read_mds(basename, iternum, endian=self.endian,
-                           dtype=self.default_dtype,
-                           shape=data_shape, llc=self.llc,
-                           llc_method=self.llc_method)
+                               dtype=self.default_dtype,
+                               shape=data_shape, llc=self.llc,
+                               llc_method=self.llc_method,
+                               extra_metadata=self.extra_metadata)
 
         for vname, data in vardata.items():
             # we now have to revert to the original prefix once the file is read
@@ -602,6 +651,7 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
                 data = np.atleast_1d(np.asarray(data).squeeze())
 
             if self.llc:
+                print(dims, data)
                 dims, data = _reshape_for_llc(dims, data)
 
             # need to add an extra dimension at the beginning if we have a time

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -25,7 +25,7 @@ from .variables import dimensions, \
 # for variable dictionaries
 
 from .utils import parse_meta_file, read_mds, parse_available_diagnostics,\
-                   get_extra_metadata
+    get_extra_metadata
 
 # Python2/3 compatibility
 if (sys.version_info > (3, 0)):

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -514,8 +514,8 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
             for (vname, dims, data, attrs) in \
                     self.load_from_prefix(p, iternum, extra_metadata):
                 # print(vname, dims, data.shape)
-                # Sizes of grid variables can vary between mitgcm versions. Check for
-                # such inconsistency and correct if so
+                # Sizes of grid variables can vary between mitgcm versions.
+                # Check for such inconsistency and correct if so
                 (vname, dims, data, attrs) = self.fix_inconsistent_variables(
                     vname, dims, data, attrs)
 

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -489,7 +489,8 @@ def test_llc_extra_metadata(llc_mds_datadirs, method):
 
     ds = xmitgcm.open_mdsdataset(dirname,
                                  iters=expected['test_iternum'],
-                                 geometry=expected['geometry'], llc_method=method,
+                                 geometry=expected['geometry'],
+                                 llc_method=method,
                                  extra_metadata=llc)
 
     assert ds.dims['face'] == 13

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -488,10 +488,9 @@ def test_llc_extra_metadata(llc_mds_datadirs, method):
     llc = xmitgcm.utils.get_extra_metadata(domain='llc', nx=nx)
 
     ds = xmitgcm.open_mdsdataset(dirname,
-                            iters=expected['test_iternum'],
-                            geometry=expected['geometry'], llc_method=method,
-                            extra_metadata=llc)
-
+                                 iters=expected['test_iternum'],
+                                 geometry=expected['geometry'], llc_method=method,
+                                 extra_metadata=llc)
 
     assert ds.dims['face'] == 13
     assert ds.rA.dims == ('face', 'j', 'i')
@@ -503,4 +502,3 @@ def test_llc_extra_metadata(llc_mds_datadirs, method):
 
     if method == "smallchunks":
         assert ds.U.chunks == (nt*(1,), nz*(1,), nface*(1,), (ny,), (nx,))
-

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -476,3 +476,31 @@ def test_ref_date(mds_datadirs_with_refdate, swap_dims, read_grid, load):
                                  read_grid=read_grid, swap_dims=swap_dims)
     if load:
         ds.time.load()
+
+
+@pytest.mark.parametrize("method", ["smallchunks"])
+def test_llc_extra_metadata(llc_mds_datadirs, method):
+    """Check that the LLC reads properly when using extra_metadata."""
+    dirname, expected = llc_mds_datadirs
+    nz, nface, ny, nx = expected['shape']
+    nt = 1
+
+    llc = xmitgcm.utils.get_extra_metadata(domain='llc', nx=nx)
+
+    ds = xmitgcm.open_mdsdataset(dirname,
+                            iters=expected['test_iternum'],
+                            geometry=expected['geometry'], llc_method=method,
+                            extra_metadata=llc)
+
+
+    assert ds.dims['face'] == 13
+    assert ds.rA.dims == ('face', 'j', 'i')
+    assert ds.rA.values.shape == (nface, ny, nx)
+    assert ds.U.dims == ('time', 'k', 'face', 'j', 'i_g')
+    assert ds.U.values.shape == (nt, nz, nface, ny, nx)
+    assert ds.V.dims == ('time', 'k', 'face', 'j_g', 'i')
+    assert ds.V.values.shape == (nt, nz, nface, ny, nx)
+
+    if method == "smallchunks":
+        assert ds.U.chunks == (nt*(1,), nz*(1,), nface*(1,), (ny,), (nx,))
+

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -251,9 +251,6 @@ def read_mds(fname, iternum=None, use_mmap=True, endian='>', shape=None,
     # transition code to keep unit tests working
     if llc:
         chunks = "2D"
-        # will be moved up into mds_store in next PR
-        llc = get_extra_metadata(domain='llc', nx=nx)
-        file_metadata.update(llc)
     # --------------- /LEGACY --------------------------
 
     # it is possible to override the values of nx, ny, nz from extra_metadata


### PR DESCRIPTION
This PR builds on the read_mds and low_level refactoring and mostly differs by the introduction
of the extra_metadata argument. Users of llc configuration are not required to pass extra_metadata
thanks to the *LEGACY* section that default extra_metadata to llc if needed. All tests passed.