### PR TITLE
Fix bug llc, fixes #102

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -365,6 +365,9 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         else:
             self.nz = nz
 
+        # if user passes extra_metadata, this should have priority
+        user_metadata = True if extra_metadata is not None else False
+
         # put in local variable to make it more readable
         if extra_metadata is not None and 'has_faces' in extra_metadata:
             has_faces = extra_metadata['has_faces']
@@ -400,7 +403,8 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
 
         # --------------- LEGACY ----------------------
         if self.llc:
-            if extra_metadata is None or 'ny_facets' not in extra_metadata:
+            #if extra_metadata is None or 'ny_facets' not in extra_metadata:
+            if not user_metadata:
                 # default to llc
                 llc = get_extra_metadata(domain='llc', nx=self.nx)
                 extra_metadata = llc

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -403,9 +403,8 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
 
         # --------------- LEGACY ----------------------
         if self.llc:
-            #if extra_metadata is None or 'ny_facets' not in extra_metadata:
             if not user_metadata:
-                # default to llc
+                # if user didn't provide metadata, we default to llc
                 llc = get_extra_metadata(domain='llc', nx=self.nx)
                 extra_metadata = llc
         # --------------- /LEGACY ----------------------

--- a/xmitgcm/test/test_utils.py
+++ b/xmitgcm/test/test_utils.py
@@ -232,7 +232,8 @@ def test_read_mds(all_mds_datadirs):
     if expected['geometry'] == 'llc':
         emeta.update({'ny': 13*270, 'nx': 270})
         with pytest.raises(AssertionError):
-            res = read_mds(basename, iternum=iternum, chunks="2D", use_dask=False,
+            res = read_mds(basename, iternum=iternum, chunks="2D", 
+                           use_dask=False,
                            use_mmap=False, extra_metadata=emeta)
 
 def test_read_mds_tokens(mds_datadirs_with_diagnostics):

--- a/xmitgcm/test/test_utils.py
+++ b/xmitgcm/test/test_utils.py
@@ -232,9 +232,10 @@ def test_read_mds(all_mds_datadirs):
     if expected['geometry'] == 'llc':
         emeta.update({'ny': 13*270, 'nx': 270})
         with pytest.raises(AssertionError):
-            res = read_mds(basename, iternum=iternum, chunks="2D", 
+            res = read_mds(basename, iternum=iternum, chunks="2D",
                            use_dask=False,
                            use_mmap=False, extra_metadata=emeta)
+
 
 def test_read_mds_tokens(mds_datadirs_with_diagnostics):
     from xmitgcm.utils import read_mds

--- a/xmitgcm/test/test_utils.py
+++ b/xmitgcm/test/test_utils.py
@@ -175,7 +175,7 @@ def test_read_mds(all_mds_datadirs):
                                     False, False, False, False,
                                     True, True, True, True, True, True]}
     else:
-        emeta = {'has_faces': False}
+        emeta = None
     res = read_mds(basename, chunks="2D", use_dask=False,
                    use_mmap=False, extra_metadata=emeta)
     assert isinstance(res, dict)
@@ -228,6 +228,12 @@ def test_read_mds(all_mds_datadirs):
     assert prefix in res
     assert isinstance(res[prefix], np.ndarray)
 
+    # check fails with bad nx, ny
+    if expected['geometry'] == 'llc':
+        emeta.update({'ny': 13*270, 'nx': 270})
+        with pytest.raises(AssertionError):
+            res = read_mds(basename, iternum=iternum, chunks="2D", use_dask=False,
+                           use_mmap=False, extra_metadata=emeta)
 
 def test_read_mds_tokens(mds_datadirs_with_diagnostics):
     from xmitgcm.utils import read_mds

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -244,6 +244,12 @@ def read_mds(fname, iternum=None, use_mmap=True, endian='>', shape=None,
 
     # extra_metadata contains informations about llc/regional llc grid
     if extra_metadata is not None:
+        nhpts_ex = extra_metadata['nx'] * extra_metadata['ny']
+        nhpts = metadata['nx'] * metadata['ny']
+        # check that nx * ny is consistent between extra_metadata and meta file
+        # unless it's a vertical profile nx = ny = 1
+        if nhpts > 1:
+            assert nhpts_ex == nhpts 
         file_metadata.update(extra_metadata)
 
     # --------------- LEGACY --------------------------

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -249,7 +249,7 @@ def read_mds(fname, iternum=None, use_mmap=True, endian='>', shape=None,
         # check that nx * ny is consistent between extra_metadata and meta file
         # unless it's a vertical profile nx = ny = 1
         if nhpts > 1:
-            assert nhpts_ex == nhpts 
+            assert nhpts_ex == nhpts
         file_metadata.update(extra_metadata)
 
     # --------------- LEGACY --------------------------


### PR DESCRIPTION
test on extra_metadata was not working as it was previously defined.
Added a condition on user defined extra_metadata, so that it defaults to the right llc domain
while preserving the ability to force the extra_metadata (needed for ASTE)