### PR TITLE
Extra grid vars

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -508,8 +508,7 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         if read_grid:
             prefixes = prefixes + list(self._all_grid_variables.keys())
             prefixes = (prefixes + 
-                    _get_extra_grid_prefixes(data_dir, 
-                                                 file_prefixes))
+                    _get_extra_grid_prefixes(data_dir))
 
         # add data files
         prefixes = (prefixes +
@@ -864,7 +863,7 @@ def _is_pickup_prefix(prefix):
             return True
     return False
 
-def _get_extra_grid_prefixes(data_dir, file_prefixes=None):
+def _get_extra_grid_prefixes(data_dir):
     """Scan a directory and return all file prefixes for extra grid files."""
     prefixes = set()
 
@@ -873,8 +872,7 @@ def _get_extra_grid_prefixes(data_dir, file_prefixes=None):
         prefix = os.path.split(f[:-5])[-1]
         # Only consider what we find that matches extra_grid_vars
         if prefix in extra_grid_variables:
-            if file_prefixes is None or prefix in file_prefixes:
-                prefixes.add(prefix)
+            prefixes.add(prefix)
 
     # order the list according to placement in extra_grid_variables
     olist = list(extra_grid_variables.keys())

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -733,7 +733,7 @@ def _get_all_grid_variables(geometry, grid_dir, layers={}):
                         'sphericalpolar': horizontal_coordinates_spherical}
     hcoords = possible_hcoords[geometry]
 
-    # look for extra variables, if they exist in grid_dir 
+    # look for extra variables, if they exist in grid_dir
     extravars = _get_extra_grid_variables(grid_dir)
 
     allvars = [hcoords, vertical_coordinates, horizontal_grid_variables,

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -616,11 +616,6 @@ extra_grid_variables = OrderedDict(
         standard_name="interior_2d_mask_at_v_location",
         long_name='OBCS 2D interior mask at v location, zero on & beyond OB',
         units='')),
-    ## Printed from write_grid when sigma coordinates are used
-    #aHybSigmF = dict(dims=['j','i'], attrs=dict(
-    #    standard_name="",
-    #    long_name='',
-    #    units='')),
     # Printed from pkg/ctrl/ctrl_init_wet when useCTRL=T
     maskCtrlC = dict(dims=['k','j','i'], attrs=dict(
         standard_name="ctrl_vector_3d_mask",
@@ -634,6 +629,10 @@ extra_grid_variables = OrderedDict(
         standard_name="ctrl_vector_3d_mask_at_v_location",
         long_name='CTRL 3D mask where ctrl vector is active at v location',
         units=''))
+    # Printed from write_grid when sigma coordinates are used
+    #AHybSigmF, BHybSigF, ...
+        # Unclear where on the grid these variables exist,
+        # skipping for now ...
 )
 
 # Nptracers=99

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -577,6 +577,64 @@ package_state_variables = {
         units='kg m-2 s-1'))
 }
 
+extra_grid_variables = OrderedDict(
+    # Printed from write_grid when debugLevel>=debugLevC 
+    rLowC = dict(dims=['j','i'], attrs=dict(
+        standard_name="depth_r0_to_bottom",
+        long_name='Depth fixed r0 to bottom at tracer location',
+        units='m')),
+    rLowW = dict(dims=['j','i_g'], attrs=dict(
+        standard_name="depth_r0_to_bottom_at_u_location",
+        long_name='Depth from fixed r0 to bottom at u location',
+        units='m')),
+    rLowS = dict(dims=['j_g','i'], attrs=dict(
+        standard_name="depth_r0_to_bottom_at_v_location",
+        long_name='Depth fixed r0 to bottom at v location',
+        units='m')),
+    rSurfC = dict(dims=['j','i'], attrs=dict(
+        standard_name="depth_r0_to_ref_surface",
+        long_name='Depth fixed r0 to reference surface level at tracer location',
+        units='m')),
+    rSurfW = dict(dims=['j','i_g'], attrs=dict(
+        standard_name="depth_r0_to_ref_surface_at_u_location",
+        long_name='Depth fixed r0 to reference surface level at u location',
+        units='m')),
+    rSurfS = dict(dims=['j_g','i'], attrs=dict(
+        standard_name="depth_r0_to_ref_surface_at_v_location",
+        long_name='Depth fixed r0 to reference surface level at v location',
+        units='m')),
+    # Printed from write_grid when useOBCS==T 
+    maskInC = dict(dims=['j','i'], attrs=dict(
+        standard_name="interior_2d_mask",
+        long_name='OBCS 2D interior mask at tracer location, zero beyond OB',
+        units='')),
+    maskInW = dict(dims=['j','i_g'], attrs=dict(
+        standard_name="interior_2d_mask_at_u_location",
+        long_name='OBCS 2D interior mask at u location, zero on & beyond OB',
+        units='')),
+    maskInS = dict(dims=['j_g','i'], attrs=dict(
+        standard_name="interior_2d_mask_at_v_location",
+        long_name='OBCS 2D interior mask at v location, zero on & beyond OB',
+        units='')),
+    ## Printed from write_grid when sigma coordinates are used
+    #aHybSigmF = dict(dims=['j','i'], attrs=dict(
+    #    standard_name="",
+    #    long_name='',
+    #    units='')),
+    # Printed from pkg/ctrl/ctrl_init_wet when useCTRL=T
+    maskCtrlC = dict(dims=['k','j','i'], attrs=dict(
+        standard_name="ctrl_vector_3d_mask",
+        long_name='CTRL 3D mask where ctrl vector is active at tracer location',
+        units='')),
+    maskCtrlW = dict(dims=['k','j','i_g'], attrs=dict(
+        standard_name="ctrl_vector_3d_mask_at_u_location",
+        long_name='CTRL 3D mask where ctrl vector is active at u location',
+        units='')),
+    maskCtrlS = dict(dims=['k','j_g','i'], attrs=dict(
+        standard_name="ctrl_vector_3d_mask_at_v_location",
+        long_name='CTRL 3D mask where ctrl vector is active at v location',
+        units=''))
+)
 
 # Nptracers=99
 # _ptracers = { 'PTRACER%02d' % n :

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -593,7 +593,8 @@ extra_grid_variables = OrderedDict(
         units='m')),
     rSurfC = dict(dims=['j','i'], attrs=dict(
         standard_name="depth_r0_to_ref_surface",
-        long_name='Depth fixed r0 to reference surface level at tracer location',
+        long_name='Depth fixed r0 to reference surface level at '
+                  'tracer location',
         units='m')),
     rSurfW = dict(dims=['j','i_g'], attrs=dict(
         standard_name="depth_r0_to_ref_surface_at_u_location",
@@ -619,7 +620,8 @@ extra_grid_variables = OrderedDict(
     # Printed from pkg/ctrl/ctrl_init_wet when useCTRL=T
     maskCtrlC = dict(dims=['k','j','i'], attrs=dict(
         standard_name="ctrl_vector_3d_mask",
-        long_name='CTRL 3D mask where ctrl vector is active at tracer location',
+        long_name='CTRL 3D mask where ctrl vector is active at '
+                  'tracer location',
         units='')),
     maskCtrlW = dict(dims=['k','j','i_g'], attrs=dict(
         standard_name="ctrl_vector_3d_mask_at_u_location",


### PR DESCRIPTION
This PR specifically address #108 as follows: 

- "extra" grid variables printed from MITgcm/model/src/write_grid.F added to variables.py as one `OrderedDict` called `extra_grid_variables`
- sigma coordinate coefficients are skipped because it's not clear to me where each of these variables exist, but happy to add them if any of you guys have experience
- added routines to mds_store.py 
   - _get_extra_grid_variables : this grabs the list of available variables
   - _get_extra_grid_prefixes : looks for prefixes in data_dir and returns a list if any of the extra_grid_vars are found

- I assumed these variables are found in data_dir rather than grid_dir because these files are output at run time, and are useful for debugging, while I would picture a users grid_dir to be somewhere on their machine that doesn't change (somewhere other than the run directory). This could be easily fixed if you guys disagree. 

