### PR TITLE
fix numerous warnings

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -266,7 +266,7 @@ def open_mdsdataset(data_dir, grid_dir=None,
 def _set_coords(ds):
     """Turn all variables without `time` dimensions into coordinates."""
     coords = set()
-    for vname in ds:
+    for vname in ds.variables:
         if ('time' not in ds[vname].dims) or (ds[vname].dims == ('time',)):
             coords.add(vname)
     return ds.set_coords(list(coords))

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -426,11 +426,12 @@ def parse_available_diagnostics(fname, layers={}):
                             suffix = 'interface'
                         else:
                             suffix = None
-                            warnings.warn("Could not match rlev = %g to a layers"
-                                          "coordiante" % rlev)
-                        # dimname = ('layer_' + layer_name + '_' + suffix if suffix
-                        dimname = (('l' + layer_name[0] + '_' + suffix[0]) if suffix
-                                   else '_UNKNOWN_')
+                            warnings.warn("Could not match rlev = %g to a "
+                                          "layers coordiante" % rlev)
+                        # dimname = ('layer_' + layer_name + '_' +
+                        #            suffix if suffix
+                        dimname = (('l' + layer_name[0] + '_' +
+                                   suffix[0]) if suffix else '_UNKNOWN_')
                         zcoord = [dimname]
                     else:
                         zcoord = ['_UNKNOWN_']

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -431,7 +431,7 @@ def parse_available_diagnostics(fname, layers={}):
                         # dimname = ('layer_' + layer_name + '_' +
                         #            suffix if suffix
                         dimname = (('l' + layer_name[0] + '_' +
-                                   suffix[0]) if suffix else '_UNKNOWN_')
+                                    suffix[0]) if suffix else '_UNKNOWN_')
                         zcoord = [dimname]
                     else:
                         zcoord = ['_UNKNOWN_']

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -408,25 +408,35 @@ def parse_available_diagnostics(fname, layers={}):
                     zcoord = []
                 elif rlev == 'R':
                     zcoord = [rcoords[rpoint]]
-                elif rlev == 'X' and layers:
-                    layer_name = key.ljust(8)[-4:].strip()
-                    n_layers = layers[layer_name]
-                    if levs == n_layers:
-                        suffix = 'bounds'
-                    elif levs == (n_layers-1):
-                        suffix = 'center'
-                    elif levs == (n_layers-2):
-                        suffix = 'interface'
+                elif rlev == 'L':
+                    # max(Nr, Nrphys) according to doc...
+                    # this seems to be only used in atmos
+                    # with different levels for dynamics and physics
+                    # setting to Nr meanwhile
+                    zcoord = [rcoords[rpoint]]
+                elif rlev == 'X':
+                    if layers:
+                        layer_name = key.ljust(8)[-4:].strip()
+                        n_layers = layers[layer_name]
+                        if levs == n_layers:
+                            suffix = 'bounds'
+                        elif levs == (n_layers-1):
+                            suffix = 'center'
+                        elif levs == (n_layers-2):
+                            suffix = 'interface'
+                        else:
+                            suffix = None
+                            warnings.warn("Could not match rlev = %g to a layers"
+                                          "coordiante" % rlev)
+                        # dimname = ('layer_' + layer_name + '_' + suffix if suffix
+                        dimname = (('l' + layer_name[0] + '_' + suffix[0]) if suffix
+                                   else '_UNKNOWN_')
+                        zcoord = [dimname]
                     else:
-                        suffix = None
-                        warnings.warn("Could not match rlev = %g to a layers"
-                                      "coordiante" % rlev)
-                    # dimname = ('layer_' + layer_name + '_' + suffix if suffix
-                    dimname = (('l' + layer_name[0] + '_' + suffix[0]) if suffix
-                               else '_UNKNOWN_')
-                    zcoord = [dimname]
+                        zcoord = ['_UNKNOWN_']
                 else:
                     warnings.warn("Not sure what to do with rlev = " + rlev)
+                    warnings.warn("corresponding diag_id  = " + str(diag_id))
                     zcoord = ['_UNKNOWN_']
                 coords = zcoord + xycoords
                 all_diags[key] = dict(dims=coords,

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -577,6 +577,65 @@ package_state_variables = {
         units='kg m-2 s-1'))
 }
 
+extra_grid_variables = OrderedDict(
+    # Printed from write_grid when debugLevel>=debugLevC
+    rLowC=dict(dims=['j', 'i'], attrs=dict(
+        standard_name="depth_r0_to_bottom",
+        long_name='Depth fixed r0 to bottom at tracer location',
+        units='m')),
+    rLowW=dict(dims=['j', 'i_g'], attrs=dict(
+        standard_name="depth_r0_to_bottom_at_u_location",
+        long_name='Depth from fixed r0 to bottom at u location',
+        units='m')),
+    rLowS=dict(dims=['j_g', 'i'], attrs=dict(
+        standard_name="depth_r0_to_bottom_at_v_location",
+        long_name='Depth fixed r0 to bottom at v location',
+        units='m')),
+    rSurfC=dict(dims=['j', 'i'], attrs=dict(
+        standard_name="depth_r0_to_ref_surface",
+        long_name='Depth fixed r0 to reference surface level at '
+                  'tracer location',
+        units='m')),
+    rSurfW=dict(dims=['j', 'i_g'], attrs=dict(
+        standard_name="depth_r0_to_ref_surface_at_u_location",
+        long_name='Depth fixed r0 to reference surface level at u location',
+        units='m')),
+    rSurfS=dict(dims=['j_g', 'i'], attrs=dict(
+        standard_name="depth_r0_to_ref_surface_at_v_location",
+        long_name='Depth fixed r0 to reference surface level at v location',
+        units='m')),
+    # Printed from write_grid when useOBCS==T
+    maskInC=dict(dims=['j', 'i'], attrs=dict(
+        standard_name="interior_2d_mask",
+        long_name='OBCS 2D interior mask at tracer location, zero beyond OB',
+        units='')),
+    maskInW=dict(dims=['j', 'i_g'], attrs=dict(
+        standard_name="interior_2d_mask_at_u_location",
+        long_name='OBCS 2D interior mask at u location, zero on & beyond OB',
+        units='')),
+    maskInS=dict(dims=['j_g', 'i'], attrs=dict(
+        standard_name="interior_2d_mask_at_v_location",
+        long_name='OBCS 2D interior mask at v location, zero on & beyond OB',
+        units='')),
+    # Printed from pkg/ctrl/ctrl_init_wet when useCTRL=T
+    maskCtrlC=dict(dims=['k', 'j', 'i'], attrs=dict(
+        standard_name="ctrl_vector_3d_mask",
+        long_name='CTRL 3D mask where ctrl vector is active at '
+                  'tracer location',
+        units='')),
+    maskCtrlW=dict(dims=['k', 'j', 'i_g'], attrs=dict(
+        standard_name="ctrl_vector_3d_mask_at_u_location",
+        long_name='CTRL 3D mask where ctrl vector is active at u location',
+        units='')),
+    maskCtrlS=dict(dims=['k', 'j_g', 'i'], attrs=dict(
+        standard_name="ctrl_vector_3d_mask_at_v_location",
+        long_name='CTRL 3D mask where ctrl vector is active at v location',
+        units=''))
+    # Printed from write_grid when sigma coordinates are used
+    # AHybSigmF, BHybSigF, ...
+    # Unclear where on the grid these variables exist,
+    # skipping for now ...
+)
 
 # Nptracers=99
 # _ptracers = { 'PTRACER%02d' % n :


### PR DESCRIPTION
* loop over datasets variables: we're looking to find variables without 'time' to turn them into coord. skipping the coords should not be a problem

* rlev = L seems to be only used in atmospheric experiments with different levels for dynamics and physics. It seems safe for now to set it to be equal to Nr

* if rlev = X and layers is not used, remove the warning since we know how to process these diags.