### PR TITLE
Calculate binary masks from hFac variables

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -544,11 +544,10 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
         return vname, dims, data, attrs
 
     def calc_masks(self, vname, data):
-        """Compute mask(C/W/S) as 1 where hFac(C/W/S) nonzero,
-           0 otherwise"""
+        """Compute mask as True where hFac nonzero, otherwise False"""
 
         if vname[0:4] == 'mask':
-            data = np.ceil(data)
+            data = data > 0
 
         return data
 

--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -21,7 +21,7 @@ from .variables import dimensions, \
     horizontal_coordinates_curvcart, horizontal_coordinates_llc, \
     vertical_coordinates, horizontal_grid_variables, vertical_grid_variables, \
     volume_grid_variables, state_variables, aliases, package_state_variables, \
-    extra_grid_variables
+    extra_grid_variables, mask_variables
 # would it be better to import mitgcm_variables and then automate the search
 # for variable dictionaries
 
@@ -524,6 +524,9 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
                 (vname, dims, data, attrs) = self.fix_inconsistent_variables(
                     vname, dims, data, attrs)
 
+                # Create masks from hFac variables
+                data = self.calc_masks(vname, data)
+
                 thisvar = xr.Variable(dims, data, attrs)
                 self._variables[vname] = thisvar
                 # print(type(data), type(thisvar._data), thisvar._in_memory)
@@ -539,6 +542,15 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
                 drc_data[-1] = 0.5 * data[-1]
                 data = drc_data
         return vname, dims, data, attrs
+
+    def calc_masks(self, vname, data):
+        """Compute mask(C/W/S) as 1 where hFac(C/W/S) nonzero,
+           0 otherwise"""
+
+        if vname[0:4] == 'mask':
+            data = np.ceil(data)
+
+        return data
 
     def load_from_prefix(self, prefix, iternum=None, extra_metadata=None):
         """Read data and look up metadata for grid variable `name`.
@@ -737,7 +749,8 @@ def _get_all_grid_variables(geometry, grid_dir, layers={}):
     extravars = _get_extra_grid_variables(grid_dir)
 
     allvars = [hcoords, vertical_coordinates, horizontal_grid_variables,
-               vertical_grid_variables, volume_grid_variables, extravars]
+               vertical_grid_variables, volume_grid_variables, mask_variables,
+               extravars]
 
     # tortured logic to add layers grid variables
     layersvars = [_make_layers_variables(layer_name)

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -433,6 +433,19 @@ def test_drc_length(all_mds_datadirs):
                 geometry=expected['geometry'])
     assert len(ds.drC)==(len(ds.drF)+1)
 
+def test_mask_values(all_mds_datadirs):
+    """Test that open_mdsdataset generates binary masks with correct values"""
+
+    dirname, expected = all_mds_datadirs
+    ds = xmitgcm.open_mdsdataset(
+                dirname, iters=None, read_grid=True,
+                geometry=expected['geometry'])
+
+    hFac_list = ['hFacC','hFacW','hFacS']
+    mask_list = ['maskC','maskW','maskS']
+
+    for hFac,mask in zip(hFac_list,mask_list):
+        assert ( ds[hFac] * ds[mask] == ds[hFac] ).all()
 
 #
 # Series of tests which try to open a dataset with different combinations of

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -425,32 +425,37 @@ def test_llc_dims(llc_mds_datadirs, method, with_refdate):
 def test_drc_length(all_mds_datadirs):
     """Test that open_mdsdataset is adding an extra level to drC if it has length nr"""
     dirname, expected = all_mds_datadirs
-    #Only older versions of the gcm have len(drC) = nr, so force len(drC) = nr for the test
-    copyfile(os.path.join(dirname, 'DRF.data'), os.path.join(dirname, 'DRC.data'))
-    copyfile(os.path.join(dirname, 'DRF.meta'), os.path.join(dirname, 'DRC.meta'))
+    # Only older versions of the gcm have len(drC) = nr, so force len(drC) = nr for the test
+    copyfile(os.path.join(dirname, 'DRF.data'),
+             os.path.join(dirname, 'DRC.data'))
+    copyfile(os.path.join(dirname, 'DRF.meta'),
+             os.path.join(dirname, 'DRC.meta'))
     ds = xmitgcm.open_mdsdataset(
-                dirname, iters=None, read_grid=True,
-                geometry=expected['geometry'])
-    assert len(ds.drC)==(len(ds.drF)+1)
+        dirname, iters=None, read_grid=True,
+        geometry=expected['geometry'])
+    assert len(ds.drC) == (len(ds.drF)+1)
+
 
 def test_mask_values(all_mds_datadirs):
     """Test that open_mdsdataset generates binary masks with correct values"""
 
     dirname, expected = all_mds_datadirs
     ds = xmitgcm.open_mdsdataset(
-                dirname, iters=None, read_grid=True,
-                geometry=expected['geometry'])
+        dirname, iters=None, read_grid=True,
+        geometry=expected['geometry'])
 
-    hFac_list = ['hFacC','hFacW','hFacS']
-    mask_list = ['maskC','maskW','maskS']
+    hFac_list = ['hFacC', 'hFacW', 'hFacS']
+    mask_list = ['maskC', 'maskW', 'maskS']
 
-    for hFac,mask in zip(hFac_list,mask_list):
-        assert ( ds[hFac] * ds[mask] == ds[hFac] ).all()
+    for hFac, mask in zip(hFac_list, mask_list):
+        assert (ds[hFac] * ds[mask] == ds[hFac]).all()
 
 #
 # Series of tests which try to open a dataset with different combinations of
 # of options, to identify if ref_date can trigger an error
 #
+
+
 @pytest.mark.parametrize("load", [True, False])
 # can't call swap_dims without read_grid=True
 @pytest.mark.parametrize("swap_dims, read_grid", [(True, True),

--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -448,7 +448,7 @@ def test_mask_values(all_mds_datadirs):
     mask_list = ['maskC', 'maskW', 'maskS']
 
     for hFac, mask in zip(hFac_list, mask_list):
-        assert (ds[hFac] * ds[mask] == ds[hFac]).all()
+        xr.testing.assert_equal(ds[hFac] * ds[mask], ds[hFac])
 
 #
 # Series of tests which try to open a dataset with different combinations of

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -213,6 +213,23 @@ volume_grid_variables = OrderedDict(
         long_name="vertical fraction of open cell"))
 )
 
+# Mask files denoting wet points
+# set filename to hFac then compute mask as 1 where hFacC nonzero
+mask_variables = OrderedDict(
+    maskC=dict(dims=['k', 'j', 'i'], attrs=dict(
+        standard_name="sea_binary_mask_at_t_location",
+        long_name="mask denoting wet point at center"),
+        filename="hFacC"),
+    maskW=dict(dims=['k', 'j', 'i_g'], attrs=dict(
+        standard_name="cell_vertical_fraction_at_u_location",
+        long_name="mask denoting wet point at interface"),
+        filename="hFacW"),
+    maskS=dict(dims=['k', 'j_g', 'i'], attrs=dict(
+        standard_name="cell_vertical_fraction_at_v_location",
+        long_name="mask denoting wet point at interface"),
+        filename="hFacS")
+)
+
 # this a template: NAME gets replaced with the layer name (e.g. 1RHO)
 #                  dim gets prepended with the layer number (e.g. l1_b)
 layers_grid_variables = OrderedDict(


### PR DESCRIPTION
This PR adds the 3D mask variables maskC/W/S to grid variables by loading the corresponding hFac variable and computing `np.ceil()` to make 0 or 1. I tried to make the meta data according to conventions discussed in #44, let me know what you think. 

This PR (eventually) resolves #44.