### PR TITLE
also search in grid_dir for avail_diags.log

### DIFF
--- a/xmitgcm/mds_store.py
+++ b/xmitgcm/mds_store.py
@@ -503,6 +503,7 @@ class _MDSDataStore(xr.backends.common.AbstractDataStore):
                                                            self.grid_dir,
                                                            self.layers)
         self._all_data_variables = _get_all_data_variables(self.data_dir,
+                                                           self.grid_dir,
                                                            self.layers)
 
         # The rest of the data has to be read from disk.
@@ -812,17 +813,25 @@ def _recursively_replace(item, search, replace):
         return item
 
 
-def _get_all_data_variables(data_dir, layers):
+def _get_all_data_variables(data_dir, grid_dir, layers):
     """"Put all the relevant data metadata into one big dictionary."""
     allvars = [state_variables]
     allvars.append(package_state_variables)
+    
     # add others from available_diagnostics.log
-    fname = os.path.join(data_dir, 'available_diagnostics.log')
-    if os.path.exists(fname):
-        diag_file = fname
+    # search in the data dir
+    fnameD = os.path.join(data_dir, 'available_diagnostics.log')
+    # and in the grid dir
+    fnameG = os.path.join(grid_dir, 'available_diagnostics.log')
+    # first look in the data dir
+    if os.path.exists(fnameD):
+        diag_file = fnameD
+    # then in the grid dir
+    elif os.path.exists(fnameG):
+        diag_file = fnameG
     else:
         warnings.warn("Couldn't find available_diagnostics.log "
-                      "in %s. Using default version." % data_dir)
+                      "in %s or %s. Using default version." % (data_dir, grid_dir)
         from .default_diagnostics import diagnostics
         diag_file = StringIO(diagnostics)
     available_diags = parse_available_diagnostics(diag_file, layers)


### PR DESCRIPTION
current behavior is to try to load available_diagnostics.log from  'data_dir' 
if the file is not there, use the xmitgcm default available_diagnostics.  

The proposed change would search in the 'grid_dir' for the 
available_diagnostics.log file if it was not found in 'data_dir'.  

In the case when the log file was in neither grid_dir nor data_dir,
we would use the xmitgcm default.