### PR TITLE
Fix deprecation errors in tests.

### DIFF
--- a/xmitgcm/test/test_mds_store.py
+++ b/xmitgcm/test/test_mds_store.py
@@ -163,11 +163,12 @@ def test_open_dataset_no_meta(all_mds_datadirs):
         assert ds['Eta'].dims == dims_2d
         assert ds['Eta'].values.ndim == len(dims_2d)
 
-        with pytest.raises(IOError, message="Expecting IOError when default_dtype "
-                                            "is not precised (i.e., None)"):
+        with pytest.raises(IOError):
             xmitgcm.open_mdsdataset(dirname, prefix=['T', 'Eta'], iters=it,
                                     geometry=expected['geometry'],
                                     read_grid=False)
+            pytest.fail("Expecting IOError when default_dtype "
+                        "is not precised (i.e., None)")
 
     # now get rid of the variables used to infer dimensions
     with hide_file(dirname, 'XC.meta', 'RC.meta'):


### PR DESCRIPTION
This PR replaces the deprecated `pytest.raises(..., message="...")` by the pytest-suggested recipe.
Fixes #167 .

[Link to the pytest docs.](https://docs.pytest.org/en/4.6-maintenance/deprecations.html#message-parameter-of-pytest-raises)

This is the reason #165 still fails. 
I hope that with these two PRs, tests will become useful again!