### PR TITLE
Fix fsspec keyword arg bug

### DIFF
--- a/xmitgcm/llcreader/__init__.py
+++ b/xmitgcm/llcreader/__init__.py
@@ -2,9 +2,9 @@ from packaging import version
 
 try:
     import fsspec
-    assert version.parse(fsspec.__version__) >= version.parse("0.2.1")
+    assert version.parse(fsspec.__version__) >= version.parse("0.4.4")
 except (ImportError, AssertionError): # pramga: no cover
-    raise ImportError('The llcreader module requires fsspec version 0.2.1 or '
+    raise ImportError('The llcreader module requires fsspec version 0.4.4 or '
                       'or greater to be installed. '
                       'To install it, run `pip install fsspec`. See '
                       'https://filesystem-spec.readthedocs.io/en/latest/ '

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -1,5 +1,4 @@
 import os
-from distutils.version import LooseVersion
 
 from .llcmodel import BaseLLCModel
 from . import stores

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -1,4 +1,5 @@
 import os
+from distutils.version import LooseVersion
 
 from .llcmodel import BaseLLCModel
 from . import stores
@@ -13,6 +14,16 @@ def _requires_pleiades(func):
         func(*args, **kwargs)
     return wrapper
 
+def _make_http_filesystem():
+    import fsspec
+    from fsspec.implementations.http import HTTPFileSystem
+
+    if LooseVersion(fsspec.__version__) >= "0.4.3":
+        kwargs = {}
+    else:
+        kwargs = {"size_policy": "get"}
+
+    return HTTPFileSystem(**kwargs)
 
 class LLC90Model(BaseLLCModel):
     nx = 90
@@ -53,8 +64,7 @@ class LLC4320Model(BaseLLCModel):
 class ECCOPortalLLC2160Model(LLC2160Model):
 
     def __init__(self):
-        from fsspec.implementations.http import HTTPFileSystem
-        fs = HTTPFileSystem(size_policy='get')
+        fs = _make_http_filesystem()
         base_path = 'https://data.nas.nasa.gov/ecco/download_data.php?file=/eccodata/llc_2160/compressed'
         mask_path = 'https://storage.googleapis.com/pangeo-ecco/llc/masks/llc_2160_masks.zarr/'
         store = stores.NestedStore(fs, base_path=base_path, mask_path=mask_path,
@@ -65,8 +75,7 @@ class ECCOPortalLLC2160Model(LLC2160Model):
 class ECCOPortalLLC4320Model(LLC4320Model):
 
     def __init__(self):
-        from fsspec.implementations.http import HTTPFileSystem
-        fs = HTTPFileSystem(size_policy='get')
+        fs = _make_http_filesystem()
         base_path = 'https://data.nas.nasa.gov/ecco/download_data.php?file=/eccodata/llc_4320/compressed'
         mask_path = 'https://storage.googleapis.com/pangeo-ecco/llc/masks/llc_4320_masks.zarr/'
         store = stores.NestedStore(fs, base_path=base_path, mask_path=mask_path,

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -17,13 +17,7 @@ def _requires_pleiades(func):
 def _make_http_filesystem():
     import fsspec
     from fsspec.implementations.http import HTTPFileSystem
-
-    if LooseVersion(fsspec.__version__) >= "0.4.3":
-        kwargs = {}
-    else:
-        kwargs = {"size_policy": "get"}
-
-    return HTTPFileSystem(**kwargs)
+    return HTTPFileSystem()
 
 class LLC90Model(BaseLLCModel):
     nx = 90

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -341,22 +341,16 @@ def _chunks(l, n):
 
 def _get_facet_chunk(store, varname, iternum, nfacet, klevels, nx, nz, dtype):
     fs, path = store.get_fs_and_full_path(varname, iternum)
-    file = fs.open(path)
 
     assert (nfacet >= 0) & (nfacet < _nfacets)
 
-    try:
-        # workaround for ecco data portal
-        file = fs.open(path, size_policy='get')
-    except TypeError:
-        file = fs.open(path)
+    file = fs.open(path)
 
     # insert singleton axis for time and k level
     facet_shape = (1, 1,) + _facet_shape(nfacet, nx)
 
     level_data = []
 
-    # TODO: get index
     # the store tells us whether we need a mask or not
     point = _get_variable_point(varname)
     if store.shrunk:


### PR DESCRIPTION
Hopefully this will fix the remaining test failures we have related to llcreader. The keyword arguments for fsspec have changed. See https://github.com/intake/filesystem_spec/issues/123 for details.