### PR TITLE
Add a function to get the full-size of xg and yg from input files

### DIFF
--- a/xmitgcm/test/test_utils.py
+++ b/xmitgcm/test/test_utils.py
@@ -973,6 +973,49 @@ def test_get_grid_from_input(all_grid_datadirs, usedask):
                                      dtype=np.dtype('d'), endian='>',
                                      use_dask=False,
                                      extra_metadata=None)
+            
+            
+            
+@pytest.mark.parametrize("usedask", [True, False])
+def test_get_xg_yg_from_input(all_grid_datadirs, usedask):
+    from xmitgcm.utils import get_xg_yg_from_input, get_extra_metadata
+    from xmitgcm.utils import read_raw_data
+    dirname, expected = all_grid_datadirs
+    md = get_extra_metadata(domain=expected['domain'], nx=expected['nx'])
+    tx=30
+    ty=30
+    bl=[1,2,3]
+    ds = get_xg_yg_from_input(dirname + '/' + expected['gridfile'],
+                             geometry=expected['geometry'],
+                             dtype=np.dtype('d'), endian='>',
+                             use_dask=usedask,
+                             extra_metadata=md,
+                             tilex=tx,tiley=ty,
+                             blankList=bl)
+    # test types
+    assert type(ds) == xarray.Dataset
+    assert type(ds['XG']) == xarray.core.dataarray.DataArray
+
+    if usedask:
+        ds.load()
+
+    # check all variables are in
+    expected_variables = ['XG', 'YG']
+
+    for var in expected_variables:
+        assert type(ds[var]) == xarray.core.dataarray.DataArray
+        assert ds[var].values.shape[1] == tx+1
+        assert ds[var].values.shape[2] ==ty+1
+
+
+    # passing llc without metadata should fail
+    if expected['geometry'] == 'llc':
+        with pytest.raises(ValueError):
+            ds = get_xg_yg_from_input(dirname + '/' + expected['gridfile'],
+                                     geometry=expected['geometry'],
+                                     dtype=np.dtype('d'), endian='>',
+                                     use_dask=False,
+                                     extra_metadata=None)
 
 
 @pytest.mark.parametrize("dtype", [np.dtype('d'), np.dtype('f')])

--- a/xmitgcm/utils.py
+++ b/xmitgcm/utils.py
@@ -1343,6 +1343,7 @@ def get_grid_from_input(gridfile, nx=None, ny=None, geometry='llc',
             grid_metadata['filename'] = fname
 
             nxgrid,nygrid=_nxgrid_nygrid(file_metadata,kfacet)
+            
 
             grid_metadata.update({'nx': nxgrid, 'ny': nygrid,
                                   'has_faces': False})


### PR DESCRIPTION
This function gets XG and YG from .mitgrid files. They are the full size (i.e. they include the points on the right hand side of the final gridpoint in both x and y directions. This is useful if you want to determine which tile and individual lat/lon point is on. 