### PR TITLE
Repair CI

### DIFF
--- a/ci/environment-py3.12.yml
+++ b/ci/environment-py3.12.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - zarr >=2.15
+  - zarr >=3.1.3
   - cftime
   - aiohttp
   - pytest-cov

--- a/ci/environment-py3.13.yml
+++ b/ci/environment-py3.13.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - zarr >=2.15
+  - zarr >=3.1.3
   - cftime
   - aiohttp
   - pytest-cov

--- a/ci/environment-xarraymaster.yml
+++ b/ci/environment-xarraymaster.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - pytest
   - future
-  - zarr >=2.15
+  - zarr >=3.1.3
   - cftime
   - aiohttp
   - pytest-cov


### PR DESCRIPTION
Updating `zarr` library version to fix CI errors. 

Error only occurred in Github Actions miniconda environments, based linux architectures. I could **not** reproduce errors in local M2 MacOS generated environments. 

CI now passes again.