### PR TITLE
Adding llcreader ASTE model on TACC featuring snapshots

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          py.test --cov=./ --cov-report=xml
+          py.test -m "not network" --cov=./ --cov-report=xml
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          py.test -m "not network" --cov=./ --cov-report=xml
+          py.test --cov=./ --cov-report=xml
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/ci/environment-py3.12.yml
+++ b/ci/environment-py3.12.yml
@@ -18,3 +18,4 @@ dependencies:
   - setuptools >=68
   - wheel
   - pip >=24
+  - libgfortran5

--- a/ci/environment-py3.12.yml
+++ b/ci/environment-py3.12.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.12
   - xarray
   - dask
-  - numpy
+  - numpy <2
   - pytest
   - future
   - zarr >=3.1.3

--- a/ci/environment-py3.12.yml
+++ b/ci/environment-py3.12.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.12
   - xarray
   - dask
-  - numpy <2
+  - numpy
   - pytest
   - future
   - zarr >=3.1.3

--- a/ci/environment-py3.13.yml
+++ b/ci/environment-py3.13.yml
@@ -18,3 +18,4 @@ dependencies:
   - setuptools >=68
   - wheel
   - pip >=24
+  - libgfortran5

--- a/ci/environment-xarraymaster.yml
+++ b/ci/environment-xarraymaster.yml
@@ -18,5 +18,6 @@ dependencies:
   - setuptools >=68
   - wheel
   - pip >=24
+  - libgfortran5
   - pip:
     - git+https://github.com/pydata/xarray.git

--- a/doc/llcreader.rst
+++ b/doc/llcreader.rst
@@ -72,7 +72,8 @@ be used right away. These are
 - ``llcreader.ECCOPortalLLC4320Model``: LLC4320 accessed via ECCO data portal
 - ``llcreader.PleiadesLLC2160Model``: LLC2160 accessed on Pleaides filesystem
 - ``llcreader.PleiadesLLC4320Model``: LLC4320 accessed on Pleaides filesystem
-- ``llcreader.CRIOSPortalASTE270Model``: ASTE Release 1 accessed via AWS
+- ``llcreader.CRIOSAWSPortalASTE270Model``: ASTE Release 1 accessed via AWS
+- ``llcreader.CRIOSTACCPortalASTE270Model``: ASTE Release 1 accessed via TACC Corral
 - ``llcreader.SverdrupASTE270Model``: ASTE Release 1 accessed on Sverdrup filesystem at UT Austin
 
 Below are a few examples of how to use these.
@@ -303,11 +304,11 @@ Because of the high-performance Lustre filesystem on Pleiades, data throughput
 should be much higher than via the ECCO data portal.
 
 
-ASTE Release 1 on AWS
-~~~~~~~~~~~~~~~~~~~~~
+ASTE Release 1 on TACC
+~~~~~~~~~~~~~~~~~~~~~~
 
-Monthly time mean output from the Arctic Subpolar gyre sTate Estimate (ASTE) Release 1
-has been made available on AWS servers.
+Monthly time mean and snapshot output from the Arctic Subpolar gyre sTate Estimate (ASTE) Release 1
+have been made available on TACC's Corral. 
 ASTE is a medium-resolution data-constrained and dynamically consistent
 ocean-sea ice synthesis, spanning 2002-2017.
 Read more about this effort in [Nguyen et al, 2020].
@@ -335,7 +336,8 @@ and this changing coordinate has been taken into account during the time average
 
 Example usage to get temperature and salinity:
    
-    >>> aste = llcreader.CRIOSPortalASTE270Model()
+   
+    >>> aste = llcreader.CRIOSTACCPortalASTE270Model()
     >>> ds = aste.get_dataset(varnames=['THETA','SALT'])
     >>> ds
     <xarray.Dataset>
@@ -405,7 +407,10 @@ All available diagnostics are shown here:
     'SIsnPrcp', 'SItflux', 'SIuice', 'SIvice', 'SRELAX', 'TFLUX', 'THETA', 'TRELAX',
     'UVELMASS', 'VVELMASS', 'WSLTMASS', 'WTHMASS', 'WVELMASS', 'oceFWflx',
     'oceQnet', 'oceQsw', 'oceSPDep', 'oceSPflx', 'oceSPtnd', 'oceSflux', 'oceTAUX',
-    'oceTAUY', 'sIceLoad']
+    'oceTAUY', 'sIceLoad', 'THETADR_snap', 'SALTDR_snap', 'ETAN_snap', 
+    'SIarea_snap', 'SIheff_snap', 'SIhsnow_snap', 'sIceLoad_snap', 'PHIBOT_snap']
+
+The monthly time mean output is also accessible via AWS using ``CRIOSAWSPortalASTE270Model``.
 
 Nguyen, A. T., H. Pillar, V. Ocana, A. Bigdeli, T. A. Smith, and P. Heimbach, 2020: The Arctic Subpolar gyre sTate Estimate (ASTE): Description and assessment of a data-constrained, dynamically consistent ocean-sea ice estimate for 2002-2017. J. Adv. Model. Earth Syst., submitted. https://doi.org/10.1002/essoar.10504669.3
 

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -59,6 +59,7 @@ class LLC2160Model(BaseLLCModel):
     mask_override = {'oceTAUX': 'c', 'oceTAUY': 'c',
                      'SIuice':  'c', 'SIvice':  'c'}
 
+
 class LLC4320Model(BaseLLCModel):
     nx = 4320
     nz = 90
@@ -145,7 +146,10 @@ class ASTE270Model(BaseLLCModel):
                 'TFLUX',    'THETA',    'TRELAX',   'UVELMASS', 'VVELMASS',
                 'WSLTMASS', 'WTHMASS',  'WVELMASS', 'oceFWflx', 'oceQnet',
                 'oceQsw',   'oceSPDep', 'oceSPflx', 'oceSPtnd', 'oceSflux',
-                'oceTAUX',  'oceTAUY',  'sIceLoad']
+                'oceTAUX',  'oceTAUY',  'sIceLoad',
+                'THETADR_snap', 'SALTDR_snap', 'ETAN_snap', 'SIarea_snap',
+                'SIheff_snap', 'SIhsnow_snap', 'sIceLoad_snap', 'PHIBOT_snap'
+                ]
 
     grid_varnames = ['AngleCS', 'AngleSN',   'DRC',       'DRF',       'DXC',
                      'DXG',     'DYC',       'DYG',       'Depth',     'PHrefC',
@@ -187,7 +191,10 @@ class ASTE270Model(BaseLLCModel):
            "oceFWflx":">f8", "oceQnet":">f8", "oceQsw":">f8",
            "oceSPDep":">f4", "oceSPflx":">f8", "oceSPtnd":">f8",
            "oceSflux":">f8", "oceTAUX":">f4", "oceTAUY":">f4",
-           "sIceLoad":">f4"}
+           "sIceLoad":">f4", "THETADR_snap":">f8", "SALTDR_snap":">f8",
+           "ETAN_snap":">f8", "SIarea_snap":">f8", "SIheff_snap":">f8",
+           "SIhsnow_snap":">f8", "sIceLoad_snap":">f8", "PHIBOT_snap":">f8"
+           }
 
 class ECCOPortalLLC2160Model(LLC2160Model):
 
@@ -244,7 +251,7 @@ class PleiadesLLC4320Model(LLC4320Model):
                                    shrunk=True,grid_path=grid_path)
         super(PleiadesLLC4320Model, self).__init__(store)
 
-class CRIOSPortalASTE270Model(ASTE270Model):
+class CRIOSAWSPortalASTE270Model(ASTE270Model):
 
     def __init__(self):
         fs = _make_http_filesystem()
@@ -255,7 +262,21 @@ class CRIOSPortalASTE270Model(ASTE270Model):
                                    mask_path=mask_path,
                                    shrunk=True, join_char='/')
 
-        super(CRIOSPortalASTE270Model, self).__init__(store)
+        super(CRIOSAWSPortalASTE270Model, self).__init__(store)
+
+class CRIOSTACCPortalASTE270Model(ASTE270Model):
+
+    def __init__(self):
+        fs = _make_http_filesystem()
+        base_path = 'https://web.corral.tacc.utexas.edu/OceanProjects/ASTE/Release1/diags_binary_wet/'
+        grid_path = 'https://web.corral.tacc.utexas.edu/OceanProjects/ASTE/Release1/diags_binary_wet/grid/'
+        mask_path = 'https://web.corral.tacc.utexas.edu/OceanProjects/ASTE/Release1/diags_binary_wet/masks.zarr'
+
+        store = stores.NestedStore(fs, base_path=base_path, grid_path=grid_path,
+                                   mask_path=mask_path,
+                                   shrunk=True, join_char='/')
+
+        super(CRIOSTACCPortalASTE270Model, self).__init__(store)
 
 class SverdrupASTE270Model(ASTE270Model):
 

--- a/xmitgcm/llcreader/known_models.py
+++ b/xmitgcm/llcreader/known_models.py
@@ -23,9 +23,17 @@ def _requires_sverdrup(func):
 
 
 def _make_http_filesystem():
+    import os
     import fsspec
-    from fsspec.implementations.http import HTTPFileSystem
-    return HTTPFileSystem()
+
+    if os.getenv("CI", "false") == "true":
+        return fsspec.filesystem(
+            "filecache",
+            target_protocol="https",
+            cache_storage="/tmp/fsspec_cache",
+        )
+
+    return fsspec.filesystem("http")
 
 class LLC90Model(BaseLLCModel):
     nx = 90

--- a/xmitgcm/llcreader/llcmodel.py
+++ b/xmitgcm/llcreader/llcmodel.py
@@ -472,7 +472,7 @@ def _get_facet_chunk(store, varname, iternum, nfacet, klevels, nx, nz, nfaces,
         mykey = nx if domain == 'global' else f'{domain}_{nx}'
         index = all_index_data[mykey][point]
         zgroup = store.open_mask_group()
-        mask = zgroup['mask_' + point].astype('bool')
+        mask = zgroup['mask_' + point][:].astype('bool')
     else:
         index = None
         mask = None
@@ -509,7 +509,7 @@ def _get_facet_chunk(store, varname, iternum, nfacet, klevels, nx, nz, nfaces,
 
         assert len(data) == (end - start)
 
-        if mask:
+        if mask is not None:
             mask_level = mask[k]
             mask_facets = _faces_to_facets(mask_level,nfaces)
             this_mask = mask_facets[nfacet]

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -178,7 +178,7 @@ def test_ecco_portal_iterations(llc_global_model):
     assert not record
 
 
-#@pytest.mark.slow
+@pytest.mark.slow
 @pytest.mark.skip(reason="ECCO Data path is depracated")
 def test_ecco_portal_load(llc_global_model):
     # an expensive test because it actually loads data
@@ -207,11 +207,12 @@ def test_ecco_portal_latlon(llc_global_model):
 
 
 ########### ASTE Portal Tests ##################################################
-#@pytest.fixture(scope='module', params=['portal','sverdrup'])
-@pytest.fixture(scope='module', params=['sverdrup'])
+@pytest.fixture(scope='module', params=['aws', 'tacc'])
 def aste_model(request):
-    if request.param == 'portal':
-        return llcreader.CRIOSPortalASTE270Model()
+    if request.param == 'aws':
+        return llcreader.CRIOSAWSPortalASTE270Model()
+    elif request.param == 'tacc':
+        return llcreader.CRIOSTACCPortalASTE270Model()
     else:
         if not os.path.exists('/scratch2/heimbach'):
             pytest.skip("Not on Sverdrup")
@@ -250,7 +251,7 @@ def test_aste_portal_iterations(aste_model):
     assert not record
 
 
-@pytest.mark.slow
+#@pytest.mark.slow
 def test_aste_portal_load(aste_model):
     # an expensive test because it actually loads data
     iters = aste_model.iters[:3]
@@ -268,4 +269,24 @@ def test_aste_portal_latlon(aste_model):
     with pytest.raises(TypeError):
         ds_ll = aste_model.get_dataset(iters=iters,type='latlon')
 
+def test_aste_tacc_snapshots(aste_model):
+    if not isinstance(aste_model, llcreader.CRIOSTACCPortalASTE270Model):
+        pytest.skip("Only testing TACC Portal snapshot variables here")
 
+    iters = aste_model.iters[0:2]
+    varnames = ['THETADR_snap', 'ETAN_snap']
+    ds = aste_model.get_dataset(varnames=varnames, iters=iters)
+
+    for vn in varnames:
+        assert vn in ds.data_vars, f"{vn} not in dataset"
+
+    nx = aste_model.nx
+    assert ds.THETADR_snap.sizes == {'time': 2, 'k': 50, 'face': 6, 'j': 270, 'i': 270}
+    assert ds.ETAN_snap.sizes == {'time': 2, 'face': 6, 'j': 270, 'i': 270}
+
+    for vn in varnames:
+        val = ds[vn].isel(time=0).isel(i=0,j=0)
+        if 'k' in val.coords:
+            val = val.isel(k=0)
+        val = val.data.compute() if isinstance(val.data, dsa) else val.data
+        assert val is not None

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -178,7 +178,7 @@ def test_ecco_portal_iterations(llc_global_model):
     assert not record
 
 
-@pytest.mark.slow
+#@pytest.mark.slow
 @pytest.mark.skip(reason="ECCO Data path is depracated")
 def test_ecco_portal_load(llc_global_model):
     # an expensive test because it actually loads data
@@ -251,7 +251,7 @@ def test_aste_portal_iterations(aste_model):
     assert not record
 
 
-#@pytest.mark.slow
+@pytest.mark.slow
 def test_aste_portal_load(aste_model):
     # an expensive test because it actually loads data
     iters = aste_model.iters[:3]

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -212,13 +212,15 @@ def aste_model(request):
     if request.param == 'aws':
         return llcreader.CRIOSAWSPortalASTE270Model()
     elif request.param == 'tacc':
-        return llcreader.CRIOSTACCPortalASTE270Model()
+        pytest.skip("Network-dependent test disabled in CI")
+        #return llcreader.CRIOSTACCPortalASTE270Model()
     else:
         if not os.path.exists('/scratch2/heimbach'):
             pytest.skip("Not on Sverdrup")
         else:
             return llcreader.SverdrupASTE270Model()
 
+@pytest.mark.network
 def test_aste_portal_faces(aste_model):
     # just get three timesteps
     iters = aste_model.iters[:3]
@@ -236,7 +238,7 @@ def test_aste_portal_faces(aste_model):
             assert len(ds_faces[fld].data.chunks)==1
             assert (len(ds_faces[fld]),)==ds_faces[fld].data.chunks[0]
 
-
+@pytest.mark.network
 def test_aste_portal_iterations(aste_model):
     with pytest.warns(RuntimeWarning, match=r"Some requested iterations may not exist, you may need to change 'iters'"):
         iters = aste_model.iters[:2]
@@ -252,6 +254,7 @@ def test_aste_portal_iterations(aste_model):
 
 
 @pytest.mark.slow
+@pytest.mark.network
 def test_aste_portal_load(aste_model):
     # an expensive test because it actually loads data
     iters = aste_model.iters[:3]
@@ -264,11 +267,13 @@ def test_aste_portal_load(aste_model):
     expected = 0.641869068145752
     assert ds_faces.ETAN[0, 1, 0, 0].values.item() == expected
 
+@pytest.mark.network
 def test_aste_portal_latlon(aste_model):
     iters = aste_model.iters[:3]
     with pytest.raises(TypeError):
         ds_ll = aste_model.get_dataset(iters=iters,type='latlon')
 
+@pytest.mark.network
 def test_aste_tacc_snapshots(aste_model):
     if not isinstance(aste_model, llcreader.CRIOSTACCPortalASTE270Model):
         pytest.skip("Only testing TACC Portal snapshot variables here")

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -212,8 +212,7 @@ def aste_model(request):
     if request.param == 'aws':
         return llcreader.CRIOSAWSPortalASTE270Model()
     elif request.param == 'tacc':
-        pytest.skip("Network-dependent test disabled in CI")
-        #return llcreader.CRIOSTACCPortalASTE270Model()
+        return llcreader.CRIOSTACCPortalASTE270Model()
     else:
         if not os.path.exists('/scratch2/heimbach'):
             pytest.skip("Not on Sverdrup")

--- a/xmitgcm/test/test_llcreader.py
+++ b/xmitgcm/test/test_llcreader.py
@@ -220,7 +220,6 @@ def aste_model(request):
         else:
             return llcreader.SverdrupASTE270Model()
 
-@pytest.mark.network
 def test_aste_portal_faces(aste_model):
     # just get three timesteps
     iters = aste_model.iters[:3]
@@ -238,7 +237,6 @@ def test_aste_portal_faces(aste_model):
             assert len(ds_faces[fld].data.chunks)==1
             assert (len(ds_faces[fld]),)==ds_faces[fld].data.chunks[0]
 
-@pytest.mark.network
 def test_aste_portal_iterations(aste_model):
     with pytest.warns(RuntimeWarning, match=r"Some requested iterations may not exist, you may need to change 'iters'"):
         iters = aste_model.iters[:2]
@@ -254,7 +252,6 @@ def test_aste_portal_iterations(aste_model):
 
 
 @pytest.mark.slow
-@pytest.mark.network
 def test_aste_portal_load(aste_model):
     # an expensive test because it actually loads data
     iters = aste_model.iters[:3]
@@ -267,13 +264,11 @@ def test_aste_portal_load(aste_model):
     expected = 0.641869068145752
     assert ds_faces.ETAN[0, 1, 0, 0].values.item() == expected
 
-@pytest.mark.network
 def test_aste_portal_latlon(aste_model):
     iters = aste_model.iters[:3]
     with pytest.raises(TypeError):
         ds_ll = aste_model.get_dataset(iters=iters,type='latlon')
 
-@pytest.mark.network
 def test_aste_tacc_snapshots(aste_model):
     if not isinstance(aste_model, llcreader.CRIOSTACCPortalASTE270Model):
         pytest.skip("Only testing TACC Portal snapshot variables here")

--- a/xmitgcm/variables.py
+++ b/xmitgcm/variables.py
@@ -757,7 +757,40 @@ package_state_variables = {
         standard_name="ADJvice",
         long_name='dJ/dvice: Sensitivity to meridional ice drift',
         mate='ADJuice',
-        units='dJ/(m s-1)'))
+        units='dJ/(m s-1)')),
+    # snapshots
+    'THETADR_snap': dict(dims=['k', 'j', 'i'], attrs=dict(
+        standard_name="THETADR_snap",
+        long_name='snapshot depth-weighted potential temperature',
+        units='degC m')),
+    'SALTDR_snap': dict(dims=['k', 'j', 'i'], attrs=dict(
+        standard_name="SALTDR_snap",
+        long_name='snapshot depth-weighted salinity',
+        units='g kg-1 m')),
+    'ETAN_snap': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="ETAN_snap",
+        long_name='snapshot sea surface height anomaly',
+        units='m')),
+    'SIarea_snap': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="SIarea_snap",
+        long_name='snapshot sea ice fractional area',
+        units=' ')),
+    'SIheff_snap': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="SIheff_snap",
+        long_name='snapshot effective sea ice thickness',
+        units='m')),
+    'SIhsnow_snap': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="SIhsnow_snap",
+        long_name='snapshot snow thickness on sea ice',
+        units='m')),
+    'sIceLoad_snap': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="SIceLoad_snap",
+        long_name='snapshot sea ice load (ice + snow)',
+        units='kg m-2')),
+    'PHIBOT_snap': dict(dims=['j', 'i'], attrs=dict(
+        standard_name="PHIBOT_snap",
+        long_name='snapshot bottom pressue',
+        units='m2 s-2')),
 }
 
 extra_grid_variables = OrderedDict(


### PR DESCRIPTION
@antnguyen13 copied ASTE Release 1 output to TACC's Corral and included snapshot diagnostics for users interested in budget closures. This PR makes that model available through llcreader. I copied the structure of #231's `CRIOSPortalASTE270Model` hosted on AWS.

I added the snapshot diagnostic names to `package_state_variables` but am open to moving it to its own dictionary. 

I found I had to update two lines in llcmodel as well in order to access the existing llcreader ASTE models. 

Added some unit tests, updated docs.