### PR TITLE
Adding libgfortran5 to pass github CI

### DIFF
--- a/ci/environment-py3.12.yml
+++ b/ci/environment-py3.12.yml
@@ -18,3 +18,4 @@ dependencies:
   - setuptools >=68
   - wheel
   - pip >=24
+  - libgfortran5

--- a/ci/environment-py3.13.yml
+++ b/ci/environment-py3.13.yml
@@ -18,3 +18,4 @@ dependencies:
   - setuptools >=68
   - wheel
   - pip >=24
+  - libgfortran5

--- a/ci/environment-xarraymaster.yml
+++ b/ci/environment-xarraymaster.yml
@@ -20,3 +20,4 @@ dependencies:
   - pip >=24
   - pip:
     - git+https://github.com/pydata/xarray.git
+  - libgfortran5


### PR DESCRIPTION
While working on PR #358, I found I needed to add `libgfortran5` to some of the environment files in order to get CI to pass. I presume this is due to upstream conda-forge package updates introducing an explicit dependency on `libgfortran5`. 